### PR TITLE
Add FIT sub-sport labels to activity naming and filters

### DIFF
--- a/src-tauri/src/fit_parser.rs
+++ b/src-tauri/src/fit_parser.rs
@@ -148,20 +148,74 @@ fn child_node<'a>(node: roxmltree::Node<'a, 'a>, name: &str) -> Option<roxmltree
         .find(|n| n.is_element() && n.tag_name().name() == name)
 }
 
-fn title_case_sport(sport: &str) -> String {
-    if sport.is_empty() {
-        return "Activity".to_string();
-    }
-    let mut chars = sport.chars();
-    let Some(first) = chars.next() else {
-        return "Activity".to_string();
-    };
-    first.to_uppercase().collect::<String>() + chars.as_str()
+fn title_case_words(value: &str) -> String {
+    let words: Vec<String> = value
+        .split(|c: char| c == '_' || c == '-' || c.is_whitespace())
+        .filter(|part| !part.is_empty())
+        .map(|part| {
+            let lower = part.to_lowercase();
+            let mut chars = lower.chars();
+            match chars.next() {
+                Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+                None => String::new(),
+            }
+        })
+        .filter(|part| !part.is_empty())
+        .collect();
+
+    words.join(" ")
 }
 
-fn build_activity_name(file_name: &str, sport: &str, points: &[RecordPoint]) -> String {
-    let fallback = strip_known_extension(file_name);
+fn title_case_sport(sport: &str) -> String {
+    let sport = sport.trim();
+    if sport.is_empty() || sport.eq_ignore_ascii_case("unknown") {
+        return "Activity".to_string();
+    }
+
+    let label = title_case_words(sport);
+    if label.is_empty() {
+        "Activity".to_string()
+    } else {
+        label
+    }
+}
+
+fn activity_type_label(sport: &str, sub_sport: Option<&str>) -> String {
     let sport_label = title_case_sport(sport);
+    let Some(raw_sub_sport) = sub_sport.map(str::trim).filter(|s| !s.is_empty()) else {
+        return sport_label;
+    };
+
+    let sub_sport_lower = raw_sub_sport.to_lowercase();
+    if matches!(sub_sport_lower.as_str(), "generic" | "all" | "unknown" | "invalid") {
+        return sport_label;
+    }
+
+    if matches!(sub_sport_lower.as_str(), "indoor_cycling" | "spin") {
+        return "Indoor Cycling".to_string();
+    }
+
+    let sub_sport_label = title_case_words(raw_sub_sport);
+    if sub_sport_label.is_empty() {
+        return sport_label;
+    }
+
+    let sport_lower = sport.trim().to_lowercase();
+    if sport_label == "Activity" || sub_sport_lower.contains(sport_lower.as_str()) {
+        sub_sport_label
+    } else {
+        format!("{sub_sport_label} {sport_label}")
+    }
+}
+
+fn build_activity_name(
+    file_name: &str,
+    sport: &str,
+    sub_sport: Option<&str>,
+    points: &[RecordPoint],
+) -> String {
+    let fallback = strip_known_extension(file_name);
+    let activity_label = activity_type_label(sport, sub_sport);
 
     if let Some(pos) = points.iter().find(|p| p.latitude.is_some() && p.longitude.is_some()) {
         let geocoder = reverse_geocoder::ReverseGeocoder::new();
@@ -177,7 +231,7 @@ fn build_activity_name(file_name: &str, sport: &str, points: &[RecordPoint]) -> 
         }
         let loc = loc_parts.join(", ");
         if !loc.is_empty() {
-            return format!("{} — {}", loc, sport_label);
+            return format!("{} — {}", loc, activity_label);
         }
     }
 
@@ -286,6 +340,7 @@ fn parse_fit_bytes(file_name: &str, bytes: &[u8]) -> Result<ParsedActivity> {
 
     let mut points: Vec<RecordPoint> = Vec::new();
     let mut sport = String::from("unknown");
+    let mut sub_sport: Option<String> = None;
     let mut device = String::new();
     let mut file_id_product_name: Option<String> = None;
     let mut file_id_manufacturer: Option<String> = None;
@@ -377,6 +432,12 @@ fn parse_fit_bytes(file_name: &str, bytes: &[u8]) -> Result<ParsedActivity> {
             for field in rec.fields() {
                 match field.name() {
                     "sport" => sport = value_string(field.value()).to_lowercase(),
+                    "sub_sport" => {
+                        let value = value_string(field.value()).to_lowercase();
+                        if !value.trim().is_empty() {
+                            sub_sport = Some(value);
+                        }
+                    }
                     "beginning_body_battery" | "start_body_battery" => {
                         session_beginning_body_battery = value_i64(field.value())
                     }
@@ -639,6 +700,7 @@ fn parse_fit_bytes(file_name: &str, bytes: &[u8]) -> Result<ParsedActivity> {
         "record_count": points.len(),
         "device": device,
         "sport": sport,
+        "sub_sport": sub_sport.as_deref(),
         "source_format": "fit",
         "file_id": {
             "product_name": file_id_combined_name,
@@ -669,7 +731,7 @@ fn parse_fit_bytes(file_name: &str, bytes: &[u8]) -> Result<ParsedActivity> {
     })
     .to_string();
 
-    let activity_name = build_activity_name(file_name, &sport, &points);
+    let activity_name = build_activity_name(file_name, &sport, sub_sport.as_deref(), &points);
 
     Ok(ParsedActivity {
         file_name: file_name.to_string(),
@@ -809,7 +871,7 @@ fn parse_tcx_bytes(file_name: &str, bytes: &[u8]) -> Result<ParsedActivity> {
     })
     .to_string();
 
-    let activity_name = build_activity_name(file_name, &sport, &points);
+    let activity_name = build_activity_name(file_name, &sport, None, &points);
 
     Ok(ParsedActivity {
         file_name: file_name.to_string(),
@@ -956,7 +1018,7 @@ fn parse_gpx_bytes(file_name: &str, bytes: &[u8]) -> Result<ParsedActivity> {
     })
     .to_string();
 
-    let activity_name = build_activity_name(file_name, &sport, &points);
+    let activity_name = build_activity_name(file_name, &sport, None, &points);
 
     Ok(ParsedActivity {
         file_name: file_name.to_string(),
@@ -978,4 +1040,48 @@ fn parse_gpx_bytes(file_name: &str, bytes: &[u8]) -> Result<ParsedActivity> {
         records: points,
         metadata_json,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn gps_point() -> RecordPoint {
+        RecordPoint {
+            timestamp_ms: 0,
+            latitude: Some(43.6532),
+            longitude: Some(-79.3832),
+            altitude_m: None,
+            distance_m: None,
+            speed_m_s: None,
+            cadence: None,
+            heart_rate: None,
+            power: None,
+            temperature_c: None,
+        }
+    }
+
+    #[test]
+    fn builds_readable_activity_type_labels() {
+        assert_eq!(activity_type_label("cycling", Some("road")), "Road Cycling");
+        assert_eq!(
+            activity_type_label("cycling", Some("gravel_cycling")),
+            "Gravel Cycling"
+        );
+        assert_eq!(activity_type_label("running", Some("trail")), "Trail Running");
+        assert_eq!(activity_type_label("running", Some("generic")), "Running");
+        assert_eq!(activity_type_label("unknown", Some("generic")), "Activity");
+    }
+
+    #[test]
+    fn uses_sub_sport_in_gps_activity_names() {
+        let name = build_activity_name(
+            "activity.fit",
+            "cycling",
+            Some("road"),
+            &[gps_point()],
+        );
+
+        assert!(name.ends_with("— Road Cycling"), "unexpected name: {name}");
+    }
 }

--- a/src-tauri/src/fit_parser.rs
+++ b/src-tauri/src/fit_parser.rs
@@ -191,8 +191,13 @@ fn activity_type_label(sport: &str, sub_sport: Option<&str>) -> String {
         return sport_label;
     }
 
-    if matches!(sub_sport_lower.as_str(), "indoor_cycling" | "spin") {
-        return "Indoor Cycling".to_string();
+    let sport_lower = sport.trim().to_lowercase();
+    if sport_lower == "cycling" {
+        match sub_sport_lower.as_str() {
+            "indoor_cycling" | "spin" => return "Indoor Cycling".to_string(),
+            "mountain" | "mountain_biking" => return "Mountain Biking".to_string(),
+            _ => {}
+        }
     }
 
     let sub_sport_label = title_case_words(raw_sub_sport);
@@ -200,7 +205,6 @@ fn activity_type_label(sport: &str, sub_sport: Option<&str>) -> String {
         return sport_label;
     }
 
-    let sport_lower = sport.trim().to_lowercase();
     if sport_label == "Activity" || sub_sport_lower.contains(sport_lower.as_str()) {
         sub_sport_label
     } else {
@@ -1064,6 +1068,7 @@ mod tests {
     #[test]
     fn builds_readable_activity_type_labels() {
         assert_eq!(activity_type_label("cycling", Some("road")), "Road Cycling");
+        assert_eq!(activity_type_label("cycling", Some("mountain")), "Mountain Biking");
         assert_eq!(
             activity_type_label("cycling", Some("gravel_cycling")),
             "Gravel Cycling"

--- a/src-tauri/src/fit_parser.rs
+++ b/src-tauri/src/fit_parser.rs
@@ -194,6 +194,7 @@ fn activity_type_label(sport: &str, sub_sport: Option<&str>) -> String {
     let sport_lower = sport.trim().to_lowercase();
     if sport_lower == "cycling" {
         match sub_sport_lower.as_str() {
+            "e_bike_fitness" => return "eBiking".to_string(),
             "indoor_cycling" | "spin" => return "Indoor Cycling".to_string(),
             "mountain" | "mountain_biking" => return "Mountain Biking".to_string(),
             _ => {}
@@ -1067,6 +1068,7 @@ mod tests {
 
     #[test]
     fn builds_readable_activity_type_labels() {
+        assert_eq!(activity_type_label("cycling", Some("e_bike_fitness")), "eBiking");
         assert_eq!(activity_type_label("cycling", Some("road")), "Road Cycling");
         assert_eq!(activity_type_label("cycling", Some("mountain")), "Mountain Biking");
         assert_eq!(

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1306,7 +1306,7 @@ export function Dashboard({ onLogout }: Props) {
                       <option value="all">{t("sidebar.allSports")}</option>
                       {sportFilterOptions.map((option) => (
                         <option key={option.value} value={option.value}>
-                          {option.depth ? `  ${option.label}` : option.label}
+                          {option.depth ? `- ${option.label}` : option.label}
                         </option>
                       ))}
                     </select></label>

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -30,7 +30,13 @@ import {
   speedLabel,
 } from "../lib/units";
 import { useTranslation } from "../lib/i18n";
-import { formatActivityTypeLabel } from "../lib/activityType";
+import {
+  activityMatchesTypeFilter,
+  formatActivityTypeLabel,
+  formatSportLabel,
+  getActivitySportFilterValue,
+  getActivityTypeFilterValue,
+} from "../lib/activityType";
 
 type Props = { onLogout: () => Promise<void> };
 
@@ -423,9 +429,10 @@ export function Dashboard({ onLogout }: Props) {
     return activities.filter((a) => {
       if (searchQuery.trim()) {
         const q = searchQuery.toLowerCase();
-        if (!`${a.activity_name} ${a.file_name} ${a.sport}`.toLowerCase().includes(q)) return false;
+        const activityType = formatActivityTypeLabel(a);
+        if (!`${a.activity_name} ${a.file_name} ${a.sport} ${activityType}`.toLowerCase().includes(q)) return false;
       }
-      if (filterSport !== "all" && a.sport !== filterSport) return false;
+      if (!activityMatchesTypeFilter(a, filterSport)) return false;
       const ts = parseUtcDate(a.start_ts_utc).getTime();
       if (Number.isFinite(ts)) {
         if (fromTs !== null && ts < fromTs) return false;
@@ -478,7 +485,34 @@ export function Dashboard({ onLogout }: Props) {
       });
   }, [tab, filtered]);
 
-  const sports = Array.from(new Set(activities.map((a) => a.sport).filter(Boolean)));
+  const sportFilterOptions = useMemo(() => {
+    const groups = new Map<string, { label: string; children: Map<string, string> }>();
+
+    for (const activity of activities) {
+      const sportValue = getActivitySportFilterValue(activity);
+      if (!sportValue) continue;
+
+      let group = groups.get(sportValue);
+      if (!group) {
+        group = { label: formatSportLabel(activity.sport), children: new Map() };
+        groups.set(sportValue, group);
+      }
+
+      const typeValue = getActivityTypeFilterValue(activity);
+      if (typeValue) {
+        group.children.set(typeValue, formatActivityTypeLabel(activity));
+      }
+    }
+
+    return Array.from(groups.entries())
+      .sort((a, b) => a[1].label.localeCompare(b[1].label, undefined, { sensitivity: "base" }))
+      .flatMap(([value, group]) => [
+        { value, label: group.label, depth: 0 },
+        ...Array.from(group.children.entries())
+          .sort((a, b) => a[1].localeCompare(b[1], undefined, { sensitivity: "base" }))
+          .map(([childValue, childLabel]) => ({ value: childValue, label: childLabel, depth: 1 })),
+      ]);
+  }, [activities]);
   const filteredSports = Array.from(new Set(filtered.map((a) => a.sport).filter(Boolean)));
   const filteredDevices = Array.from(new Set(filtered.map((a) => a.device).filter(Boolean)));
   const selectedRecords = tab === "overview" ? overviewRecords : records;
@@ -1270,7 +1304,11 @@ export function Dashboard({ onLogout }: Props) {
                   <div className="filter-fields">
                     <label>{t("sidebar.sport")}<select value={filterSport} onChange={(e) => setFilterSport(e.target.value)}>
                       <option value="all">{t("sidebar.allSports")}</option>
-                      {sports.map((s) => <option key={s} value={s}>{s}</option>)}
+                      {sportFilterOptions.map((option) => (
+                        <option key={option.value} value={option.value}>
+                          {option.depth ? `  ${option.label}` : option.label}
+                        </option>
+                      ))}
                     </select></label>
                     <label>
                       {t("sidebar.dateRange")}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -30,6 +30,7 @@ import {
   speedLabel,
 } from "../lib/units";
 import { useTranslation } from "../lib/i18n";
+import { formatActivityTypeLabel } from "../lib/activityType";
 
 type Props = { onLogout: () => Promise<void> };
 
@@ -1562,7 +1563,7 @@ export function Dashboard({ onLogout }: Props) {
                   <h2>{selectedActivity.activity_name || selectedActivity.file_name}</h2>
                   <div className="detail-badges">
                     <span className="badge">{formatDate(selectedActivity.start_ts_utc)}</span>
-                    {selectedActivity.sport && <span className="badge sport">{selectedActivity.sport}</span>}
+                    {selectedActivity.sport && <span className="badge sport">{formatActivityTypeLabel(selectedActivity)}</span>}
                     {deviceBadgeSerial && <span className="badge device">SN {deviceBadgeSerial}</span>}
                     <label className="detail-toggle-badge" title={t("detail.smoothGraphsTooltip")}>
                       <input

--- a/src/components/OverviewActivityTable.tsx
+++ b/src/components/OverviewActivityTable.tsx
@@ -3,6 +3,7 @@ import type { Activity } from "../types";
 import { useSettingsStore } from "../stores/settingsStore";
 import { distanceDivisor, distanceLabel, speedLabel, type DistanceUnit } from "../lib/units";
 import { useTranslation } from "../lib/i18n";
+import { formatActivityTypeLabel } from "../lib/activityType";
 
 type Props = {
   activities: Activity[];
@@ -95,7 +96,7 @@ export function OverviewActivityTable({ activities, distanceUnit, timeFormat }: 
           id: activity.id,
           date,
           name: activity.activity_name || activity.file_name,
-          sport: activity.sport || "Unknown",
+          sport: formatActivityTypeLabel(activity),
           durationS: activity.duration_s,
           distanceM: activity.distance_m,
           avgSpeedInUnit,

--- a/src/components/OverviewSportTypeDonut.tsx
+++ b/src/components/OverviewSportTypeDonut.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import ReactECharts from "echarts-for-react";
 import type { Activity } from "../types";
 import { useTranslation } from "../lib/i18n";
+import { formatActivityTypeLabel } from "../lib/activityType";
 
 type Props = {
   activities: Activity[];
@@ -21,7 +22,7 @@ export function OverviewSportTypeDonut({ activities, theme }: Props) {
   const data = useMemo(() => {
     const counts = new Map<string, number>();
     for (const activity of activities) {
-      const key = (activity.sport || "Unknown").trim() || "Unknown";
+      const key = formatActivityTypeLabel(activity);
       counts.set(key, (counts.get(key) ?? 0) + 1);
     }
 

--- a/src/lib/activityType.ts
+++ b/src/lib/activityType.ts
@@ -16,6 +16,11 @@ const CYCLING_SUB_SPORT_LABELS: Record<string, string> = {
   mountain_biking: "Mountain Biking",
 };
 
+const CYCLING_SUB_SPORT_ALIASES: Record<string, string> = {
+  spin: "indoor_cycling",
+  mountain_biking: "mountain",
+};
+
 function titleCaseWords(value: string): string {
   return value
     .trim()
@@ -28,10 +33,16 @@ function titleCaseWords(value: string): string {
     .join(" ");
 }
 
+function normalizedSport(sport?: string | null): string | null {
+  const trimmed = sport?.trim().toLowerCase();
+  if (!trimmed || trimmed === "unknown") return null;
+  return trimmed;
+}
+
 function titleCaseSport(sport?: string | null): string {
-  const trimmed = sport?.trim();
-  if (!trimmed || trimmed.toLowerCase() === "unknown") return "Activity";
-  return titleCaseWords(trimmed) || "Activity";
+  const sportKey = normalizedSport(sport);
+  if (!sportKey) return "Activity";
+  return titleCaseWords(sportKey) || "Activity";
 }
 
 function metadataSubSport(raw?: string): string | null {
@@ -55,23 +66,32 @@ function metadataSubSport(raw?: string): string | null {
   }
 }
 
-export function formatActivityType(sport?: string | null, subSport?: string | null): string {
-  const sportLabel = titleCaseSport(sport);
-  const trimmedSubSport = subSport?.trim();
-  if (!trimmedSubSport) return sportLabel;
+function normalizedSubSport(sport?: string | null, subSport?: string | null): string | null {
+  const trimmedSubSport = subSport?.trim().toLowerCase();
+  if (!trimmedSubSport || IGNORED_SUB_SPORTS.has(trimmedSubSport)) return null;
 
-  const subSportLower = trimmedSubSport.toLowerCase();
-  if (IGNORED_SUB_SPORTS.has(subSportLower)) return sportLabel;
-
-  const sportLower = sport?.trim().toLowerCase() ?? "";
-  if (sportLower === "cycling" && CYCLING_SUB_SPORT_LABELS[subSportLower]) {
-    return CYCLING_SUB_SPORT_LABELS[subSportLower];
+  const sportKey = normalizedSport(sport);
+  if (sportKey === "cycling") {
+    return CYCLING_SUB_SPORT_ALIASES[trimmedSubSport] ?? trimmedSubSport;
   }
 
-  const subSportLabel = titleCaseWords(trimmedSubSport);
+  return trimmedSubSport;
+}
+
+export function formatActivityType(sport?: string | null, subSport?: string | null): string {
+  const sportLabel = titleCaseSport(sport);
+  const subSportKey = normalizedSubSport(sport, subSport);
+  if (!subSportKey) return sportLabel;
+
+  const sportKey = normalizedSport(sport) ?? "";
+  if (sportKey === "cycling" && CYCLING_SUB_SPORT_LABELS[subSportKey]) {
+    return CYCLING_SUB_SPORT_LABELS[subSportKey];
+  }
+
+  const subSportLabel = titleCaseWords(subSportKey);
   if (!subSportLabel) return sportLabel;
 
-  if (sportLabel === "Activity" || (sportLower && subSportLower.includes(sportLower))) {
+  if (sportLabel === "Activity" || (sportKey && subSportKey.includes(sportKey))) {
     return subSportLabel;
   }
 
@@ -80,4 +100,41 @@ export function formatActivityType(sport?: string | null, subSport?: string | nu
 
 export function formatActivityTypeLabel(activity: Pick<Activity, "sport" | "metadata_json">): string {
   return formatActivityType(activity.sport, metadataSubSport(activity.metadata_json));
+}
+
+export function formatSportLabel(sport?: string | null): string {
+  return titleCaseSport(sport);
+}
+
+export function getSportFilterValue(sport?: string | null): string | null {
+  const sportKey = normalizedSport(sport);
+  return sportKey ? `sport:${sportKey}` : null;
+}
+
+export function getActivitySportFilterValue(activity: Pick<Activity, "sport">): string | null {
+  return getSportFilterValue(activity.sport);
+}
+
+export function getActivityTypeFilterValue(activity: Pick<Activity, "sport" | "metadata_json">): string | null {
+  const sportKey = normalizedSport(activity.sport);
+  const subSportKey = normalizedSubSport(activity.sport, metadataSubSport(activity.metadata_json));
+  if (!sportKey || !subSportKey) return null;
+  return `type:${sportKey}:${subSportKey}`;
+}
+
+export function activityMatchesTypeFilter(
+  activity: Pick<Activity, "sport" | "metadata_json">,
+  filterValue: string,
+): boolean {
+  if (filterValue === "all") return true;
+
+  if (filterValue.startsWith("sport:")) {
+    return getActivitySportFilterValue(activity) === filterValue;
+  }
+
+  if (filterValue.startsWith("type:")) {
+    return getActivityTypeFilterValue(activity) === filterValue;
+  }
+
+  return activity.sport === filterValue;
 }

--- a/src/lib/activityType.ts
+++ b/src/lib/activityType.ts
@@ -1,0 +1,83 @@
+import type { Activity } from "../types";
+
+type ActivityMetadata = {
+  sub_sport?: unknown;
+  session?: {
+    sub_sport?: unknown;
+  };
+};
+
+const IGNORED_SUB_SPORTS = new Set(["generic", "all", "unknown", "invalid"]);
+
+const CYCLING_SUB_SPORT_LABELS: Record<string, string> = {
+  indoor_cycling: "Indoor Cycling",
+  spin: "Indoor Cycling",
+  mountain: "Mountain Biking",
+  mountain_biking: "Mountain Biking",
+};
+
+function titleCaseWords(value: string): string {
+  return value
+    .trim()
+    .split(/[\s_/-]+/)
+    .filter(Boolean)
+    .map((word) => {
+      const lower = word.toLowerCase();
+      return `${lower.charAt(0).toUpperCase()}${lower.slice(1)}`;
+    })
+    .join(" ");
+}
+
+function titleCaseSport(sport?: string | null): string {
+  const trimmed = sport?.trim();
+  if (!trimmed || trimmed.toLowerCase() === "unknown") return "Activity";
+  return titleCaseWords(trimmed) || "Activity";
+}
+
+function metadataSubSport(raw?: string): string | null {
+  if (!raw) return null;
+
+  try {
+    const parsed = JSON.parse(raw) as ActivityMetadata | null;
+    if (!parsed || typeof parsed !== "object") return null;
+
+    const value =
+      typeof parsed.sub_sport === "string"
+        ? parsed.sub_sport
+        : typeof parsed.session?.sub_sport === "string"
+          ? parsed.session.sub_sport
+          : null;
+
+    const trimmed = value?.trim();
+    return trimmed ? trimmed : null;
+  } catch {
+    return null;
+  }
+}
+
+export function formatActivityType(sport?: string | null, subSport?: string | null): string {
+  const sportLabel = titleCaseSport(sport);
+  const trimmedSubSport = subSport?.trim();
+  if (!trimmedSubSport) return sportLabel;
+
+  const subSportLower = trimmedSubSport.toLowerCase();
+  if (IGNORED_SUB_SPORTS.has(subSportLower)) return sportLabel;
+
+  const sportLower = sport?.trim().toLowerCase() ?? "";
+  if (sportLower === "cycling" && CYCLING_SUB_SPORT_LABELS[subSportLower]) {
+    return CYCLING_SUB_SPORT_LABELS[subSportLower];
+  }
+
+  const subSportLabel = titleCaseWords(trimmedSubSport);
+  if (!subSportLabel) return sportLabel;
+
+  if (sportLabel === "Activity" || (sportLower && subSportLower.includes(sportLower))) {
+    return subSportLabel;
+  }
+
+  return `${subSportLabel} ${sportLabel}`;
+}
+
+export function formatActivityTypeLabel(activity: Pick<Activity, "sport" | "metadata_json">): string {
+  return formatActivityType(activity.sport, metadataSubSport(activity.metadata_json));
+}

--- a/src/lib/activityType.ts
+++ b/src/lib/activityType.ts
@@ -10,6 +10,7 @@ type ActivityMetadata = {
 const IGNORED_SUB_SPORTS = new Set(["generic", "all", "unknown", "invalid"]);
 
 const CYCLING_SUB_SPORT_LABELS: Record<string, string> = {
+  e_bike_fitness: "eBiking",
   indoor_cycling: "Indoor Cycling",
   spin: "Indoor Cycling",
   mountain: "Mountain Biking",


### PR DESCRIPTION
Closes #17.
Fixes #49.

## Summary
- Read FIT session `sub_sport` metadata and use it when generating GPS-derived activity names.
- Display readable activity type labels such as `Road Cycling`, `Mountain Biking`, `Indoor Cycling`, and Garmin e-bike activities as `eBiking` in the activity detail badge, overview table, and sport/type donut.
- Extend the sport filter so users can select the parent sport, such as `Cycling`, or a specific subtype, such as `Road Cycling`.
- Include readable activity type labels in search matching.

## Notes
- Parent sport filter options still include all activities for that sport.
- Subtype filter options are generated from imported activities, so the dropdown only shows subtypes present in the local data.
- Generic/unknown FIT sub-sport values continue to fall back to the base sport label.
- The raw FIT-derived values remain unchanged; for example, `sub_sport = e_bike_fitness` is stored as metadata while the display label is `eBiking`.
- Existing persisted activity names are not rewritten automatically; reimporting or renaming is required for old generated names to change.

## Testing
- `npm run build`
- `cargo test --features web fit_parser::tests`
- Local Docker rebuild with `docker compose -f docker/docker-compose-build.yml -f docker/docker-compose.override.yml up -d --build`
- Confirmed local deployment serves HTTP 200 on port `8088`
- Confirmed rebuilt frontend bundle contains the `eBiking` label
