### PR TITLE
Use FIT timer fields for activity duration

### DIFF
--- a/src-tauri/src/fit_parser.rs
+++ b/src-tauri/src/fit_parser.rs
@@ -242,6 +242,72 @@ fn total_distance_m(points: &[RecordPoint]) -> f64 {
         .unwrap_or(0.0)
 }
 
+fn valid_duration_s(value: Option<f64>) -> Option<f64> {
+    value.filter(|v| v.is_finite() && *v > 0.0)
+}
+
+fn add_valid_duration_s(total: &mut Option<f64>, value: Option<f64>) {
+    if let Some(duration) = valid_duration_s(value) {
+        *total = Some(total.unwrap_or(0.0) + duration);
+    }
+}
+
+fn select_fit_duration_s(
+    session_total_timer_time_sum_s: Option<f64>,
+    activity_total_timer_time_s: Option<f64>,
+    lap_total_timer_time_sum_s: Option<f64>,
+    session_total_elapsed_time_sum_s: Option<f64>,
+    record_span_duration_s: f64,
+) -> (f64, &'static str) {
+    if let Some(duration) = valid_duration_s(session_total_timer_time_sum_s) {
+        return (duration, "sessions.total_timer_time_sum");
+    }
+    if let Some(duration) = valid_duration_s(activity_total_timer_time_s) {
+        return (duration, "activity.total_timer_time");
+    }
+    if let Some(duration) = valid_duration_s(lap_total_timer_time_sum_s) {
+        return (duration, "laps.total_timer_time_sum");
+    }
+    if let Some(duration) = valid_duration_s(session_total_elapsed_time_sum_s) {
+        return (duration, "sessions.total_elapsed_time_sum");
+    }
+
+    (record_span_duration_s.max(0.0), "record_timestamp_span")
+}
+
+fn select_fit_time_range_ms(
+    record_start_ts: i64,
+    record_end_ts: i64,
+    session_start_ts: Option<i64>,
+    session_end_ts: Option<i64>,
+    duration_s: f64,
+) -> (i64, i64) {
+    let start_ts = session_start_ts.unwrap_or(record_start_ts);
+    let mut end_ts = session_end_ts.unwrap_or(record_end_ts).max(start_ts);
+    let current_span_ms = end_ts - start_ts;
+    let duration_ms = (duration_s * 1000.0).round();
+
+    if duration_ms.is_finite() && duration_ms > current_span_ms as f64 {
+        if let Some(duration_end_ts) = start_ts.checked_add(duration_ms as i64) {
+            end_ts = duration_end_ts;
+        }
+    }
+
+    (start_ts, end_ts)
+}
+
+fn update_min_ts(slot: &mut Option<i64>, value: Option<i64>) {
+    if let Some(ts) = value {
+        *slot = Some(slot.map_or(ts, |current| current.min(ts)));
+    }
+}
+
+fn update_max_ts(slot: &mut Option<i64>, value: Option<i64>) {
+    if let Some(ts) = value {
+        *slot = Some(slot.map_or(ts, |current| current.max(ts)));
+    }
+}
+
 fn first_valid_coordinates(points: &[RecordPoint]) -> (Option<f64>, Option<f64>) {
     if let Some(point) = points
         .iter()
@@ -305,9 +371,15 @@ fn parse_fit_bytes(file_name: &str, bytes: &[u8]) -> Result<ParsedActivity> {
     let mut session_avg_heart_rate: Option<i64> = None;
     let mut session_max_cadence: Option<i64> = None;
     let mut session_avg_cadence: Option<i64> = None;
-    let mut session_total_elapsed_time_s: Option<f64> = None;
+    let mut session_count: i64 = 0;
+    let mut session_start_ts: Option<i64> = None;
+    let mut session_end_ts: Option<i64> = None;
+    let mut session_total_elapsed_time_sum_s: Option<f64> = None;
+    let mut session_total_timer_time_sum_s: Option<f64> = None;
     let mut session_total_distance_m: Option<f64> = None;
     let mut session_total_calories: Option<i64> = None;
+    let mut activity_total_timer_time_s: Option<f64> = None;
+    let mut lap_total_timer_time_sum_s: Option<f64> = None;
     let mut lap_ranges: Vec<serde_json::Value> = Vec::new();
     let mut heart_rate_zone_bounds_bpm: Vec<i64> = Vec::new();
 
@@ -374,9 +446,16 @@ fn parse_fit_bytes(file_name: &str, bytes: &[u8]) -> Result<ParsedActivity> {
                 });
             }
         } else if rec.kind() == MesgNum::Session {
+            session_count += 1;
             for field in rec.fields() {
                 match field.name() {
                     "sport" => sport = value_string(field.value()).to_lowercase(),
+                    "start_time" => {
+                        update_min_ts(&mut session_start_ts, value_timestamp_ms(field.value()))
+                    }
+                    "timestamp" => {
+                        update_max_ts(&mut session_end_ts, value_timestamp_ms(field.value()))
+                    }
                     "beginning_body_battery" | "start_body_battery" => {
                         session_beginning_body_battery = value_i64(field.value())
                     }
@@ -387,7 +466,18 @@ fn parse_fit_bytes(file_name: &str, bytes: &[u8]) -> Result<ParsedActivity> {
                     "avg_heart_rate" => session_avg_heart_rate = value_i64(field.value()),
                     "max_cadence" => session_max_cadence = value_i64(field.value()),
                     "avg_cadence" => session_avg_cadence = value_i64(field.value()),
-                    "total_elapsed_time" => session_total_elapsed_time_s = value_f64(field.value()),
+                    "total_elapsed_time" => {
+                        add_valid_duration_s(
+                            &mut session_total_elapsed_time_sum_s,
+                            value_f64(field.value()),
+                        )
+                    }
+                    "total_timer_time" => {
+                        add_valid_duration_s(
+                            &mut session_total_timer_time_sum_s,
+                            value_f64(field.value()),
+                        )
+                    }
                     "total_distance" => session_total_distance_m = value_f64(field.value()),
                     "total_calories" => session_total_calories = value_i64(field.value()),
                     _ => {}
@@ -493,6 +583,12 @@ fn parse_fit_bytes(file_name: &str, bytes: &[u8]) -> Result<ParsedActivity> {
                     }
                 }
             }
+        } else if rec.kind() == MesgNum::Activity {
+            for field in rec.fields() {
+                if field.name() == "total_timer_time" {
+                    activity_total_timer_time_s = value_f64(field.value());
+                }
+            }
         } else if rec.kind() == MesgNum::Lap {
             let mut lap_start_ms: Option<i64> = None;
             let mut lap_end_ms: Option<i64> = None;
@@ -543,6 +639,10 @@ fn parse_fit_bytes(file_name: &str, bytes: &[u8]) -> Result<ParsedActivity> {
                     "total_calories" => lap_total_calories = value_i64(field.value()),
                     _ => {}
                 }
+            }
+
+            if let Some(duration) = valid_duration_s(lap_total_timer_time_s) {
+                lap_total_timer_time_sum_s = Some(lap_total_timer_time_sum_s.unwrap_or(0.0) + duration);
             }
 
             lap_ranges.push(serde_json::json!({
@@ -607,13 +707,27 @@ fn parse_fit_bytes(file_name: &str, bytes: &[u8]) -> Result<ParsedActivity> {
         }
     }
 
-    let start_ts = min_ts.ok_or_else(|| anyhow!("FIT file had no timestamped records"))?;
-    let end_ts = max_ts.unwrap_or(start_ts);
+    let record_start_ts = min_ts.ok_or_else(|| anyhow!("FIT file had no timestamped records"))?;
+    let record_end_ts = max_ts.unwrap_or(record_start_ts);
 
     derive_distance_if_missing(&mut points);
     derive_speed_if_missing(&mut points);
 
-    let duration_s = ((end_ts - start_ts).max(0) as f64) / 1000.0;
+    let record_span_duration_s = ((record_end_ts - record_start_ts).max(0) as f64) / 1000.0;
+    let (duration_s, duration_source) = select_fit_duration_s(
+        session_total_timer_time_sum_s,
+        activity_total_timer_time_s,
+        lap_total_timer_time_sum_s,
+        session_total_elapsed_time_sum_s,
+        record_span_duration_s,
+    );
+    let (start_ts, end_ts) = select_fit_time_range_ms(
+        record_start_ts,
+        record_end_ts,
+        session_start_ts,
+        session_end_ts,
+        duration_s,
+    );
     let distance_m = total_distance_m(&points);
     let (start_latitude, start_longitude) = first_valid_coordinates(&points);
 
@@ -639,6 +753,12 @@ fn parse_fit_bytes(file_name: &str, bytes: &[u8]) -> Result<ParsedActivity> {
         "record_count": points.len(),
         "device": device,
         "sport": sport,
+        "duration_source": duration_source,
+        "record_span_duration_s": record_span_duration_s,
+        "record_start_ts_utc": chrono::DateTime::from_timestamp_millis(record_start_ts)
+            .map(|dt| dt.to_rfc3339()),
+        "record_end_ts_utc": chrono::DateTime::from_timestamp_millis(record_end_ts)
+            .map(|dt| dt.to_rfc3339()),
         "source_format": "fit",
         "file_id": {
             "product_name": file_id_combined_name,
@@ -653,15 +773,26 @@ fn parse_fit_bytes(file_name: &str, bytes: &[u8]) -> Result<ParsedActivity> {
         "activity_metrics": {
             "vo2_max": vo2_max
         },
+        "activity": {
+            "total_timer_time_s": activity_total_timer_time_s
+        },
         "heart_rate_zone_bounds_bpm": heart_rate_zone_bounds_bpm,
         "session": {
+            "count": session_count,
+            "start_ts_utc": session_start_ts
+                .and_then(chrono::DateTime::from_timestamp_millis)
+                .map(|dt| dt.to_rfc3339()),
+            "end_ts_utc": session_end_ts
+                .and_then(chrono::DateTime::from_timestamp_millis)
+                .map(|dt| dt.to_rfc3339()),
             "beginning_body_battery": session_beginning_body_battery,
             "ending_body_battery": session_ending_body_battery,
             "max_heart_rate": session_max_heart_rate,
             "avg_heart_rate": session_avg_heart_rate,
             "max_cadence": session_max_cadence,
             "avg_cadence": session_avg_cadence,
-            "total_elapsed_time_s": session_total_elapsed_time_s,
+            "total_elapsed_time_s": session_total_elapsed_time_sum_s,
+            "total_timer_time_s": session_total_timer_time_sum_s,
             "total_distance_m": session_total_distance_m,
             "total_calories": session_total_calories
         },
@@ -978,4 +1109,125 @@ fn parse_gpx_bytes(file_name: &str, bytes: &[u8]) -> Result<ParsedActivity> {
         records: points,
         metadata_json,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fit_duration_accumulates_valid_session_timer_values() {
+        let mut total = None;
+        add_valid_duration_s(&mut total, Some(1_000.0));
+        add_valid_duration_s(&mut total, Some(0.0));
+        add_valid_duration_s(&mut total, Some(1_651.675));
+        add_valid_duration_s(&mut total, Some(f64::NAN));
+
+        assert!((total.unwrap() - 2_651.675).abs() < 0.000_001);
+    }
+
+    #[test]
+    fn fit_duration_prefers_session_timer_time_sum() {
+        let (duration, source) = select_fit_duration_s(
+            Some(2_651.675),
+            Some(2_700.0),
+            Some(2_700.0),
+            Some(2_705.309),
+            2_705.0,
+        );
+
+        assert_eq!(duration, 2_651.675);
+        assert_eq!(source, "sessions.total_timer_time_sum");
+    }
+
+    #[test]
+    fn fit_duration_uses_activity_timer_before_lap_sum() {
+        let (duration, source) = select_fit_duration_s(
+            None,
+            Some(606_452.96),
+            Some(3_217.111),
+            Some(606_452.96),
+            3_217.0,
+        );
+
+        assert_eq!(duration, 606_452.96);
+        assert_eq!(source, "activity.total_timer_time");
+    }
+
+    #[test]
+    fn fit_duration_uses_lap_timer_sum_before_elapsed_time() {
+        let (duration, source) = select_fit_duration_s(
+            None,
+            None,
+            Some(2_651.675),
+            Some(2_705.309),
+            2_705.0,
+        );
+
+        assert_eq!(duration, 2_651.675);
+        assert_eq!(source, "laps.total_timer_time_sum");
+    }
+
+    #[test]
+    fn fit_duration_falls_back_to_elapsed_then_record_span() {
+        let (elapsed_duration, elapsed_source) = select_fit_duration_s(
+            None,
+            None,
+            None,
+            Some(2_705.309),
+            2_705.0,
+        );
+        assert_eq!(elapsed_duration, 2_705.309);
+        assert_eq!(elapsed_source, "sessions.total_elapsed_time_sum");
+
+        let (record_duration, record_source) =
+            select_fit_duration_s(None, None, None, None, 2_705.0);
+        assert_eq!(record_duration, 2_705.0);
+        assert_eq!(record_source, "record_timestamp_span");
+    }
+
+    #[test]
+    fn fit_duration_ignores_zero_or_invalid_timer_values() {
+        let (duration, source) = select_fit_duration_s(
+            Some(0.0),
+            Some(f64::NAN),
+            Some(-1.0),
+            Some(2_705.309),
+            2_705.0,
+        );
+
+        assert_eq!(duration, 2_705.309);
+        assert_eq!(source, "sessions.total_elapsed_time_sum");
+    }
+
+    #[test]
+    fn fit_time_range_uses_session_bounds_when_available() {
+        let (start_ts, end_ts) = select_fit_time_range_ms(
+            10_000,
+            70_000,
+            Some(0),
+            Some(120_000),
+            60.0,
+        );
+
+        assert_eq!(start_ts, 0);
+        assert_eq!(end_ts, 120_000);
+    }
+
+    #[test]
+    fn fit_time_range_extends_sparse_record_range_to_duration() {
+        let (start_ts, end_ts) = select_fit_time_range_ms(0, 60_000, None, None, 120.0);
+
+        assert_eq!(start_ts, 0);
+        assert_eq!(end_ts, 120_000);
+    }
+
+    #[test]
+    fn fit_time_range_does_not_shorten_elapsed_record_range() {
+        let (start_ts, end_ts) =
+            select_fit_time_range_ms(0, 2_705_309, None, None, 2_651.675);
+
+        assert_eq!(start_ts, 0);
+        assert_eq!(end_ts, 2_705_309);
+    }
 }


### PR DESCRIPTION
Fixes #23

## Summary
- Prefer FIT timer duration fields when importing activity duration.
- Fall back through activity, lap, session elapsed, and record-span timing only when stronger timer fields are unavailable.
- Add parser helpers and unit coverage for FIT timer duration and time-range handling.

## Why
Some FIT files include stopped/restarted recording time or stopwatch split behavior where the record timestamp span does not match the activity duration shown by Garmin Connect. Using FIT timer fields gives the importer a duration that better matches Garmin Connect and FIT timer semantics.

## Testing
- `cargo test fit_duration` passed during local validation.
- `cargo test fit_time_range` passed during local validation.
- Local Docker deployment was rebuilt from local `main` after merging this branch for integration testing.


Before:
See duration is indicated as 53:37
<img width="422" height="277" alt="Image" src="https://github.com/user-attachments/assets/fe6c849a-223a-4d94-bced-6893ad4f9045" />

After:
See fixed duration in the Activity list which matches the Lap table.
<img width="909" height="166" alt="image" src="https://github.com/user-attachments/assets/972042c1-08f7-481b-8e03-9cefc02ebd8c" />
