### PR TITLE
docs: propose multisport activity support

### DIFF
--- a/docs/features/multisport-deferred.md
+++ b/docs/features/multisport-deferred.md
@@ -61,12 +61,23 @@ needed sooner.
 
 ## Export and Compare
 
-- Child-row export.
-  - MVP can remain parent-only if needed.
-  - Future work could export the currently selected child leg records.
-- Child-row compare.
-  - MVP should keep compare parent-only unless child rows are represented clearly
-    in the compare selection UI.
+- Multisport parent export.
+  - Future work should define a deliberate parent export shape, such as parent
+    summary plus child summaries, original FIT download, or a clearly labelled
+    combined telemetry export.
+  - Parent export should not silently reuse a normal single-sport activity export
+    because parent records contain mixed sports and mixed output streams.
+- Multisport parent compare.
+  - Parent compare needs a deliberate design because parent data mixes sports,
+    output streams, and segment semantics.
+  - Future work should decide whether parent compare is disabled, summary-only,
+    or represented by a multisport-specific compare view.
+- Multisport child-leg compare.
+  - Child-leg compare may be able to reuse existing compare behavior, but that is
+    not part of the first-slice design.
+  - Future work should verify whether compare can accept `activity_id` plus
+    `segment_index`, segment labels, segment summaries, and segment-scoped
+    records.
 
 ## Test Fixtures
 

--- a/docs/features/multisport-deferred.md
+++ b/docs/features/multisport-deferred.md
@@ -1,0 +1,76 @@
+# Multisport Deferred Items
+
+Parking lot for issue #21 follow-up work. These are intentionally out of scope
+for the first implementation pass unless the implementation proves they are
+needed sooner.
+
+## Database and Migration
+
+- Automatic additive migration for existing DuckDB databases.
+  - First pass targets a fresh schema.
+  - Likely future work if upstream wants existing users to upgrade without
+    wiping/reimporting.
+- First-class `activity_laps` table.
+  - MVP keeps laps in `metadata_json.laps` with segment assignment fields.
+  - Future work can migrate all lap display to `activity_laps` and add a general
+    lap API.
+
+## Activity List and Navigation
+
+- URL/query-string support for opening a specific child leg directly.
+  - MVP keeps selected child leg in frontend state.
+  - Future URL support should use stable `segment_index`, not database
+    `segment_id`.
+- Detail-page segment selector.
+  - MVP selects parent/child legs from the activity list only.
+- Child leg rename/custom labels.
+  - MVP uses generated names from sport/sub-sport and transition order.
+  - Future work could add `activity_segments.custom_name` and a segment-specific
+    rename endpoint.
+
+## Overview
+
+- Leg-aware Overview aggregation.
+  - MVP Overview remains parent-activity based.
+  - Future work could report matching child-leg distance, duration, counts,
+    heatmap entries, weekly trend entries, and activity-type donut slices.
+- Leg composition chart or leg-aware activity-type donut.
+  - MVP Activity Types donut counts the parent as `Multisport`.
+  - Future work could show bike/run/transition share inside a multisport event or
+    inside filtered/search results.
+
+## Detail Page and Maps
+
+- Garmin Connect-style parent detail page.
+  - MVP reuses the existing Individual tab layout for both parent and child
+    selections.
+- Segment-colored route overlays.
+  - MVP maps render the selected record set.
+  - Future work could color parent routes by segment and mark segment boundaries.
+- Manual leg-boundary editing.
+
+## Calculations and Insights
+
+- Parent-level sport-specific calculations on mixed-sport data.
+  - Parent calculation behavior is TBD after the first implementation slice.
+  - Segment-scoped calculations are the safer path because each child leg has one
+    sport/sub-sport and expected output stream.
+- Heart-rate drift on multisport.
+  - If/when HR drift exists upstream, it should be disabled on multisport parent
+    activities and evaluated on eligible child legs only.
+
+## Export and Compare
+
+- Child-row export.
+  - MVP can remain parent-only if needed.
+  - Future work could export the currently selected child leg records.
+- Child-row compare.
+  - MVP should keep compare parent-only unless child rows are represented clearly
+    in the compare selection UI.
+
+## Test Fixtures
+
+- Upstream-safe multisport FIT fixture.
+  - Synthetic parsed-data tests are safest for MVP.
+  - A fabricated or sanitized FIT binary requires extra tooling because FIT is a
+    binary format with checksums and possible personal/GPS data.

--- a/docs/features/multisport-implementation-plan.md
+++ b/docs/features/multisport-implementation-plan.md
@@ -1,0 +1,459 @@
+# Multisport Support Implementation Plan
+
+## Status
+
+Implementation planning notes for issue #21. This document is intended to sit
+beside the design proposal and translate it into an ordered build plan.
+
+The design proposal is in `docs/features/multisport-support.md`.
+
+## Implementation Principles
+
+- Keep the first pass narrow: parent and child selections reuse the existing
+  Individual tab layout.
+- Put multisport selection in the activity list. Parent rows expand to child
+  leg rows.
+- Child rows appear on parent expansion and can also appear in search/filter
+  results when they match.
+- Do not double-count child rows in overview totals.
+- Preserve existing single-sport behavior.
+- Treat automatic database migration as deferred but likely future work. Build
+  the first implementation against a fresh schema.
+
+## Current Code Baseline
+
+### Backend
+
+- `src-tauri/src/fit_parser.rs`
+  - Parses `record`, `session`, and `lap` messages.
+  - Session fields are stored in single local variables, so multiple sessions
+    overwrite earlier session values.
+  - Laps are collected into `metadata_json.laps`.
+- `src-tauri/src/models.rs`
+  - `ParsedActivity` has one flat activity summary and one flat record list.
+  - `RecordPoint` has no segment identifier.
+- `src-tauri/src/database.rs`
+  - `activities` stores one row per imported file.
+  - `records` stores telemetry rows keyed only by `activity_id`.
+  - There is no `activity_segments` table.
+  - There is no `activity_laps` table.
+  - `delete_activity` deletes `records`, then `activities`.
+  - `records_downsampled(activity_id, resolution_ms)` returns all records for
+    one activity.
+- `src-tauri/src/server.rs`
+  - `GET /api/records/{activity_id}` returns downsampled activity records.
+  - There are no segment or lap endpoints.
+
+### Frontend
+
+- `src/stores/activityStore.ts`
+  - Stores one selected activity and one `records` array.
+  - `selectActivity(activity)` fetches all records for `activity.id`.
+- `src/components/Dashboard.tsx`
+  - The sidebar renders one row per imported activity.
+  - Sport/search/date/duration filtering is based on the activity list.
+  - Activity details, charts, map, stats, and insights render from the selected
+    activity and selected `records`.
+  - The lap table is built from `selectedActivity.metadata_json.laps`.
+- `src/components/ActivityInsights.tsx`
+  - Existing upstream insights are telemetry charts, not persisted calculations.
+  - There is no heart-rate drift feature in upstream at the time of this plan.
+
+## Decisions For First Pass
+
+### Migration Timing
+
+Implement on a fresh database first. Automatic additive migration is deferred but
+likely future work.
+
+Reasoning:
+
+- Parser, segment assignment, insert/delete, API, and UI behavior can be tested
+  more directly on a fresh schema.
+- Migration code adds compatibility complexity and should not block the first
+  implementation slice.
+- Upstream maintainer preference is not known yet. The first implementation can
+  document the fresh-database requirement, then add automatic migration later if
+  upstream wants existing databases to upgrade without wipe/reimport.
+
+### Lap Scope
+
+First pass: keep laps in `metadata_json.laps` and add segment assignment fields
+to those lap objects for multisport imports. Defer first-class `activity_laps`.
+
+Current app support:
+
+- Laps are supported in the UI today, but only through `metadata_json.laps`.
+- Laps are not supported as database rows or API resources.
+
+Implementation choice:
+
+- Keep existing `metadata_json.laps` shape unchanged for compatibility.
+- For single-sport activities, continue using existing metadata-backed laps.
+- For multisport, add fields such as `segment_index`, `segment_type`, `sport`,
+  and `sub_sport` to each lap metadata object when assignment is known.
+- Parent view reads all `metadata_json.laps`.
+- Child view filters `metadata_json.laps` by selected `segment_index`.
+- Laps with unknown segment assignment remain visible only in the parent view.
+- Do not add `activity_laps` or migrate all activity types to first-class laps in
+  the first pass.
+
+Deferred/future cleanup:
+
+- Add `activity_laps` for first-class lap storage.
+- Migrate all lap display to `activity_laps`.
+- Add a general lap API for every activity type.
+- Stop relying on `metadata_json.laps` for display after compatibility is proven.
+
+### Child Row Naming and Editing
+
+Child rows should have generated display names, not independent user-editable
+activity names in the first pass.
+
+Recommended generated names:
+
+- Sport legs: use the same sport/sub-sport display logic as normal activities,
+  but without location. For example, `Indoor Cycling`, `Running`, `Walking`,
+  `Cycling`, or repeated labels such as `Indoor Cycling 2` when needed.
+- Transition legs: `T1`, `T2`, etc.
+
+Parent activity names remain user-editable through the existing rename path.
+
+Do not add child rename support in the first pass because child rows are not
+standalone activities and should not be updated by the existing
+`renameActivity(activity_id, name)` endpoint. If editable child labels are later
+needed, add a separate `activity_segments.display_name` or
+`activity_segments.custom_name` field and a segment-specific rename endpoint.
+
+### Parent Calculation Policy
+
+The upstream app currently has generic telemetry visualizations and summary
+stats, but no persisted sport-specific calculation framework and no heart-rate
+drift feature.
+
+First pass:
+
+- Parent view shows normal activity summary, charts, map, laps, and existing
+  insights using full parent records.
+- Treat these as whole-activity telemetry views, not sport-specific performance
+  calculations.
+- Parent calculation behavior is TBD until after the first implementation slice
+  exposes parent and child records cleanly.
+- Segment views may run sport-specific calculations later because they are scoped
+  to one leg with one sport/sub-sport and one expected output metric.
+
+Known future interaction:
+
+- Heart-rate drift, if added later, should be disabled on multisport parent
+  activities and available only on eligible child segments.
+
+Parent calculation options to review after the first slice:
+
+- Leave existing upstream insight charts visible on parent as raw whole-activity
+  telemetry.
+- Show only clearly generic parent views: summary stats, map, laps, heart-rate
+  chart, and elevation chart.
+- Hide the insights grid on multisport parent and require child selection for
+  leg-level analysis.
+
+## Build Sequence
+
+### 1. Add Domain Types
+
+Add typed parser/domain structures for:
+
+- FIT activity summary.
+- FIT session summary.
+- FIT lap summary.
+- Parsed segment.
+- Parsed lap metadata with optional segment assignment.
+- Parsed activity with optional segments and segment-tagged lap metadata.
+
+Keep existing `ParsedActivity` behavior for single-sport imports while expanding
+it to carry child data.
+
+### 2. Preserve FIT Activity, Sessions, and Laps
+
+Update `fit_parser.rs` to preserve:
+
+- The FIT `activity` message.
+- Every FIT `session` message in message order.
+- Every FIT `lap` message in message order.
+- Session and lap sport/sub-sport.
+- Session and lap `start_time`, `total_timer_time`, and
+  `total_elapsed_time`.
+
+Do not rely on `session.timestamp` or `lap.timestamp` as an end time for
+multisport assignment.
+
+### 3. Detect Multisport
+
+Treat a file as multisport when:
+
+- FIT activity type is `auto_multi_sport`; or
+- multiple session messages form a multisport pattern with distinct session
+  starts and sport/sub-sport changes, including transition sessions.
+
+Keep detection conservative. If the file does not clearly match, preserve
+current single-activity behavior.
+
+### 4. Assign Records and Laps to Segments
+
+Derive segment boundaries from session `start_time` and adjacent session starts.
+
+Use half-open intervals `[start, end)` for assignment.
+
+Record assignment:
+
+- Assign each record to the segment interval containing its timestamp.
+- If overlapping intervals exist, assign to the matching segment with the latest
+  start time.
+- Count unassigned and overlapping records in import diagnostics.
+
+Lap assignment:
+
+- Assign by lap `start_time` against segment intervals.
+- If `start_time` is missing, use FIT message order and lap sport/sub-sport.
+- If ambiguous, omit `segment_index` from the lap metadata so the lap remains
+  visible in the parent view only.
+
+### 5. Add Fresh Schema Support
+
+Add schema for:
+
+- `activities.activity_kind`.
+- `records.segment_id`.
+- `activity_segments`.
+- `activity_laps` is deferred; keep laps in `metadata_json.laps` for MVP.
+
+Fresh-schema implementation can add these directly in `init_schema` before
+automatic migration work is added.
+
+### 6. Update Insert, Delete, and Rollback
+
+Update insert flow:
+
+1. Insert parent activity.
+2. Insert segments.
+3. Store segment-tagged laps in parent `metadata_json.laps`.
+4. Insert records with `segment_id`.
+
+Use one transaction where possible.
+
+Update delete and rollback flow:
+
+1. Delete records.
+2. Delete segments.
+3. Delete parent activity.
+
+Keep blacklist behavior unchanged: user deletion still adds the file hash to the
+blacklist after DB rows are removed.
+
+### 7. Add Segment and Lap APIs
+
+Web:
+
+- Add `GET /api/activities/{activity_id}/segments`.
+- Do not add a lap endpoint in the first pass; keep laps in activity metadata.
+- Extend `GET /api/records/{activity_id}` with optional segment filtering.
+
+Desktop/Tauri:
+
+- Add matching command for segment list.
+- Extend `get_records` with optional segment filtering.
+
+Adapters:
+
+- Keep web and desktop API behavior aligned.
+- Use `segment_index` in frontend state, resolving it to `segment_id`
+  internally for API calls. Route/query-string support for selected child legs is
+  deferred as a likely future enhancement; if added later, expose stable
+  `segment_index` in the URL rather than database `segment_id`.
+
+### 8. Update Frontend State
+
+Extend `activityStore` to track:
+
+- Selected parent activity.
+- Optional selected segment index.
+- Selected records scoped to parent or child.
+- Segment list for the selected parent.
+- Laps scoped to parent or child from segment-tagged activity metadata.
+
+When no segment is selected, fetch parent records and use parent laps.
+
+When a segment is selected, fetch segment-scoped records and show only laps for
+that segment when lap scoping is available.
+
+### 9. Update Activity List
+
+Add expandable parent rows:
+
+- Parent row opens the whole activity.
+- Expanding the row shows child legs.
+- Child row opens the same Individual tab scoped to that segment.
+- Child rows are visually subordinate.
+- Transition rows are visible and selectable, but visually de-emphasized.
+
+Search/filter behavior:
+
+- Parent rows participate in filters as before.
+- Child rows also participate in search/filtering.
+- Filtering for `running` may show the running child row without showing the
+  cycling or transition sibling rows.
+- If a matching child row is shown, show a compact parent context row with only
+  the applicable matching children beneath it.
+- Child rows must not increase overview totals or activity counts.
+
+### 10. Reuse Individual Tab Layout
+
+Do not add a detail-page segment selector in the first pass.
+
+Parent selected:
+
+- Existing Individual tab layout renders full parent activity data.
+
+Child selected:
+
+- Existing Individual tab layout renders selected segment data.
+
+Transition selected:
+
+- Existing Individual tab layout renders transition data as a generic GPS
+  movement segment when streams exist.
+
+### 11. Update Overview UI
+
+Overview remains parent-activity based in the first pass. The current Overview
+page does use the sidebar filters because `Dashboard.tsx` passes the filtered
+activity array into the overview cards, heatmap, donut, map, weekly trend, and
+table. A multisport event and its child legs count as one activity for overview
+statistics. Child legs do not add separate overview counts, totals, averages,
+heatmap cells, weekly trend entries, sport donut slices, or overview table rows.
+
+Overview cards:
+
+- Filtered activity count counts the parent once.
+- Total distance uses the parent activity distance.
+- Total duration uses the parent activity duration.
+- Average distance and average duration divide by the number of parent
+  activities, not by the number of child legs.
+- Unique sports should include `Multisport` as the parent sport/category. It
+  should not count every child sport as a separate overview activity type unless
+  a later leg-level overview is added.
+
+Activity Contributions heatmap:
+
+- Current implementation counts activities per calendar day. It does not use
+  distance, duration, or intensity.
+- For each activity, `ActivityContributionHeatmap` buckets
+  `activity.start_ts_utc` by local day and increments that day by one.
+- Cell color is relative to the busiest day in the displayed range:
+  - `0`: grey `rgba(148, 163, 184, 0.20)`
+  - `count / maxCount < 0.25`: `#155e75`
+  - `count / maxCount < 0.5`: `#0891b2`
+  - `count / maxCount < 0.75`: `#06b6d4`
+  - otherwise: `#22d3ee`
+- A multisport parent contributes one count on its parent start date. Child legs
+  do not add additional heatmap counts.
+
+Weekly Training Trend:
+
+- Current implementation sums distance and duration per parent activity week.
+- A multisport parent contributes its parent distance and parent duration once.
+- Child legs do not create separate weekly entries.
+
+Sport Type Donut:
+
+- Current implementation is the Activity Types donut. It counts parent
+  activities by `activity.sport`; it does not measure distance, duration, or leg
+  composition.
+- Multisport parents should use a parent sport/category such as `Multisport`.
+- Child legs should not be counted in the donut in the first pass. A leg-aware
+  donut or separate leg composition chart, such as showing bike/run/transition
+  share inside a multisport event or inside filtered/search results, is future
+  enhancement.
+
+Overview activity table:
+
+- Show one row for the multisport parent.
+- Do not show child legs as separate rows in the overview table for the first
+  pass.
+- The parent row may show a small multisport/leg-count indicator if it can be
+  done without changing table behavior.
+
+Filtering nuance:
+
+- The activity list can expose child rows when search/filter criteria match a
+  leg.
+- Overview statistics should still aggregate parent activities only.
+- If a filter matches a child leg, include the parent activity once in overview
+  totals rather than counting the child as a separate activity. This preserves
+  the rule that the event is one activity.
+- Reporting matching child-leg distance, duration, count, heatmap entries,
+  weekly trend entries, or donut slices is future enhancement. That would require
+  a leg-aware Overview aggregation model instead of passing only parent
+  activities into the current Overview components.
+
+### 12. Exports and Compare
+
+Keep export and compare behavior parent-only for the first pass. Child-row export
+and child-row compare are second-pass items tracked in
+`docs/features/multisport-deferred.md`.
+
+### 13. Automatic Migration Deferred
+
+Automatic migration is deferred but likely future work and tracked in
+`docs/features/multisport-deferred.md`. The first implementation pass targets a
+fresh schema.
+
+## Test Plan
+
+Backend parser tests:
+
+- Single-sport FIT import remains unchanged.
+- Multisport FIT preserves all sessions.
+- Multisport FIT preserves all laps.
+- Session fields are not overwritten by later sessions.
+- Activity message data is preserved.
+- Transition sessions are detected as child legs.
+
+Segment assignment tests:
+
+- Records assign to expected segment by timestamp.
+- Laps assign to expected segment by start time.
+- Missing or ambiguous laps remain parent-only.
+- Overlap and unassigned diagnostics are recorded.
+
+Database tests:
+
+- Fresh DB creates new tables/columns.
+- Multisport insert writes parent metadata with segment-tagged laps, segments,
+  and records.
+- Delete removes records, segments, and parent.
+- Failed import rollback removes all child rows.
+- Overview totals count parent only.
+
+API/Tauri tests:
+
+- Parent records endpoint returns all parent records.
+- Segment-scoped records endpoint returns only child records.
+- Parent view reads all metadata laps.
+- Child view filters metadata laps by selected segment index.
+- Web and Tauri commands return matching shapes.
+
+Frontend tests:
+
+- Parent row expands to child rows.
+- Child row selection scopes records, map, charts, stats, and laps.
+- Search/filter can show matching child rows.
+- Overview totals do not double-count children.
+- Parent rename still works.
+- Child rows are not user-editable in the first pass.
+
+Migration tests are deferred with automatic migration.
+
+## Deferred
+
+Deferred and second-pass items are tracked in
+`docs/features/multisport-deferred.md`.

--- a/docs/features/multisport-implementation-plan.md
+++ b/docs/features/multisport-implementation-plan.md
@@ -17,6 +17,11 @@ The design proposal is in `docs/features/multisport-support.md`.
   results when they match.
 - Do not double-count child rows in overview totals.
 - Preserve existing single-sport behavior.
+- Limit multisport support to FIT files. Garmin Connect FIT downloads from the
+  parent or from selected legs can contain the same full parent multisport FIT
+  payload. Garmin Connect TCX and GPX downloads from selected legs are
+  leg-specific exports, not parent multisport exports, and stay out of scope for
+  multisport detection.
 - Treat automatic database migration as deferred but likely future work. Build
   the first implementation against a fresh schema.
 
@@ -172,6 +177,11 @@ Add typed parser/domain structures for:
 Keep existing `ParsedActivity` behavior for single-sport imports while expanding
 it to carry child data.
 
+Only FIT files participate in multisport detection and segment extraction. TCX and
+GPX parsers keep their existing single-activity behavior. Garmin Connect
+leg-specific TCX/GPX exports should import as ordinary single activities, not as
+multisport parents.
+
 ### 2. Preserve FIT Activity, Sessions, and Laps
 
 Update `fit_parser.rs` to preserve:
@@ -224,7 +234,7 @@ Add schema for:
 - `activities.activity_kind`.
 - `records.segment_id`.
 - `activity_segments`.
-- `activity_laps` is deferred; keep laps in `metadata_json.laps` for MVP.
+- Do not add `activity_laps` in the first pass; keep laps in `metadata_json.laps` for MVP.
 
 Fresh-schema implementation can add these directly in `init_schema` before
 automatic migration work is added.
@@ -249,7 +259,15 @@ Update delete and rollback flow:
 Keep blacklist behavior unchanged: user deletion still adds the file hash to the
 blacklist after DB rows are removed.
 
-### 7. Add Segment and Lap APIs
+Backend validation checkpoint:
+
+- Multisport FIT import stores the parent activity, segments, segment-tagged lap
+  metadata, and segment-scoped records.
+- Deleting a multisport parent removes records, segments, and the parent row.
+- Failed import rollback removes any partial child rows.
+- Single-sport FIT, TCX, and GPX imports keep existing single-activity behavior.
+
+### 7. Add Segment APIs and Record Scoping
 
 Web:
 
@@ -285,7 +303,7 @@ When no segment is selected, fetch parent records and use parent laps.
 When a segment is selected, fetch segment-scoped records and show only laps for
 that segment when lap scoping is available.
 
-### 9. Update Activity List
+### 9a. Add Expandable Activity List Rows
 
 Add expandable parent rows:
 
@@ -294,6 +312,8 @@ Add expandable parent rows:
 - Child row opens the same Individual tab scoped to that segment.
 - Child rows are visually subordinate.
 - Transition rows are visible and selectable, but visually de-emphasized.
+
+### 9b. Add Child Row Search and Filter Behavior
 
 Search/filter behavior:
 
@@ -397,9 +417,16 @@ Filtering nuance:
 
 ### 12. Exports and Compare
 
-Keep export and compare behavior parent-only for the first pass. Child-row export
-and child-row compare are second-pass items tracked in
-`docs/features/multisport-deferred.md`.
+Support export for the selected child leg by reusing the existing export shape
+with segment-scoped records. Single-sport activity export remains unchanged.
+
+Disable or suppress export for multisport parent rows in the first pass unless a
+clearly labelled parent-summary export is designed. Parent-level multisport
+export is deferred in `docs/features/multisport-deferred.md`.
+
+Compare behavior is not explicitly designed in the first pass. Preserve existing
+single-sport compare behavior. Do not add special multisport parent or child
+compare support in this slice.
 
 ### 13. Automatic Migration Deferred
 
@@ -411,6 +438,10 @@ fresh schema.
 
 Backend parser tests:
 
+- TCX and GPX imports keep existing single-activity behavior and do not enter
+  multisport detection.
+- TCX distance correction is tracked separately in issue #29 and is not part
+  of this multisport implementation.
 - Single-sport FIT import remains unchanged.
 - Multisport FIT preserves all sessions.
 - Multisport FIT preserves all laps.

--- a/docs/features/multisport-support.md
+++ b/docs/features/multisport-support.md
@@ -1,0 +1,450 @@
+# Multisport Activity Support
+
+## Status
+
+Design proposal for issue #21.
+
+## Problem
+
+FIT Dashboard currently imports an activity file as one activity. Garmin
+multisport files can represent one parent activity with multiple sessions or
+legs, for example bike, transition, run, transition, bike. Flattening these into
+one normal activity can make the activity name, map, charts, summary metrics,
+filters, and sport-specific calculations misleading.
+
+The current parser already reads `record`, `session`, and `lap` messages, but the
+database model stores records against only an `activity_id`, stores laps in
+activity metadata JSON, and presents one activity row. There is no first-class
+sub-activity or leg view.
+
+## Goals
+
+- Detect FIT multisport activities during import.
+- Preserve the parent activity and each FIT session as a child leg.
+- Keep transitions as child legs, but visually de-emphasize them.
+- Let users view either the whole activity or one selected leg.
+- Scope stats, maps, charts, laps, and calculations to the selected view.
+- Prevent child legs from being double-counted in overview totals.
+- Keep existing single-sport activity behavior unchanged.
+
+## Non-Goals
+
+- Splitting a multisport FIT file into unrelated standalone activities.
+- Supporting manual editing of leg boundaries in the first implementation.
+- Rewriting all chart and statistics code in one step if a narrower MVP can
+  preserve correctness.
+- Adding support for unrelated non-activity FIT file types.
+
+## FIT Observations
+
+An anonymized Garmin multisport sample was inspected for design guidance. It had:
+
+- One FIT `activity` message with `type = auto_multi_sport`.
+- Five FIT `session` messages.
+- Twenty-five FIT `lap` messages.
+- A mix of indoor cycling, transition, running, transition, and indoor cycling
+  legs.
+- GPS records only in the transition and running legs. The indoor cycling legs
+  had no GPS records.
+- Heart-rate records throughout the legs.
+- Power records in the cycling legs and also in the running leg for this sample.
+
+Important parser nuance: in this sample, the FIT `session.timestamp` and
+`lap.timestamp` values were not usable as segment end times. They repeated the
+parent activity timestamp. The parser must not assume `timestamp` is the end of a
+session or lap. Use `start_time` plus `total_timer_time` or `total_elapsed_time`,
+and use adjacent session starts as assignment boundaries when available.
+
+## Data Model
+
+Keep `activities` as the parent activity table. Add child segments rather than
+creating fake child activities with duplicate file hashes.
+
+### activities
+
+Add fields:
+
+- `activity_kind VARCHAR DEFAULT 'single'`
+  - `single`: current behavior.
+  - `multisport_parent`: a parent activity with child segments.
+- `parent_summary_json VARCHAR` or extend existing `metadata_json`
+  - Stores parent-level FIT activity data, raw session summaries, and migration
+    helpers.
+
+For multisport parents:
+
+- `sport` should be `multisport`.
+- `activity_name` should not be derived from GPS from only one child leg.
+- `duration_s` should use FIT activity `total_timer_time` when present, then
+  fall back to the sum of session timer durations.
+- `distance_m` should use FIT activity total distance when present, then fall
+  back to the sum of session distances.
+
+### activity_segments
+
+Create a new table:
+
+```sql
+CREATE TABLE IF NOT EXISTS activity_segments (
+    id BIGINT PRIMARY KEY,
+    activity_id BIGINT NOT NULL,
+    segment_index BIGINT NOT NULL,
+    segment_type VARCHAR NOT NULL,
+    name VARCHAR NOT NULL,
+    sport VARCHAR,
+    sub_sport VARCHAR,
+    start_ts_utc TIMESTAMP,
+    end_ts_utc TIMESTAMP,
+    timer_duration_s REAL,
+    elapsed_duration_s REAL,
+    distance_m REAL,
+    start_latitude DOUBLE,
+    start_longitude DOUBLE,
+    metadata_json VARCHAR
+);
+```
+
+Recommended `segment_type` values:
+
+- `sport`
+- `transition`
+
+Indexes:
+
+```sql
+CREATE INDEX IF NOT EXISTS idx_activity_segments_activity
+    ON activity_segments(activity_id, segment_index);
+```
+
+### records
+
+Add a nullable `segment_id`:
+
+```sql
+ALTER TABLE records ADD COLUMN IF NOT EXISTS segment_id BIGINT;
+CREATE INDEX IF NOT EXISTS idx_records_segment_time
+    ON records(segment_id, timestamp_ms);
+```
+
+Existing single-sport records can keep `segment_id = NULL`. Multisport records
+should keep their parent `activity_id` and also receive the matching
+`segment_id`.
+
+### laps
+
+The existing importer stores laps inside `metadata_json`. Multisport needs laps
+to be scoped to a selected leg, so add a first-class lap table:
+
+```sql
+CREATE TABLE IF NOT EXISTS activity_laps (
+    id BIGINT PRIMARY KEY,
+    activity_id BIGINT NOT NULL,
+    segment_id BIGINT,
+    lap_index BIGINT NOT NULL,
+    start_ts_utc TIMESTAMP,
+    end_ts_utc TIMESTAMP,
+    timer_duration_s REAL,
+    elapsed_duration_s REAL,
+    distance_m REAL,
+    avg_speed_m_s REAL,
+    max_speed_m_s REAL,
+    avg_heart_rate BIGINT,
+    max_heart_rate BIGINT,
+    avg_cadence BIGINT,
+    max_cadence BIGINT,
+    total_ascent_m REAL,
+    total_descent_m REAL,
+    total_calories BIGINT,
+    metadata_json VARCHAR
+);
+```
+
+Indexes:
+
+```sql
+CREATE INDEX IF NOT EXISTS idx_activity_laps_activity
+    ON activity_laps(activity_id, lap_index);
+CREATE INDEX IF NOT EXISTS idx_activity_laps_segment
+    ON activity_laps(segment_id, lap_index);
+```
+
+## Import and Parser Rules
+
+### Detection
+
+Treat a FIT file as multisport when:
+
+1. The FIT `activity.type` is `auto_multi_sport` or another recognized
+   multisport activity type.
+2. Or the file contains more than one FIT `session` with distinct session start
+   times and at least one sport transition.
+
+Condition 1 is the strongest signal. Condition 2 is a fallback for compatible
+files that encode multiple sessions without the expected activity type.
+
+### Segment Ordering
+
+Order segments by:
+
+1. `session.start_time` when available.
+2. FIT message order as fallback.
+
+Each segment gets a stable `segment_index` starting at 1.
+
+### Segment Boundaries
+
+For each session:
+
+- `segment_start = session.start_time`.
+- `segment_timer_end = segment_start + session.total_timer_time` when available.
+- `segment_elapsed_end = segment_start + session.total_elapsed_time` when
+  available.
+- `segment_assignment_end`:
+  - next session `start_time` when available;
+  - otherwise `segment_elapsed_end`;
+  - otherwise `segment_timer_end`;
+  - otherwise the parent activity end.
+
+Use half-open intervals `[start, end)` for assigning records and laps. This
+prevents boundary samples from being double-counted.
+
+Do not use `session.timestamp` as the end time unless validation shows it is
+later than `start_time` and consistent with the session duration.
+
+### Record Assignment
+
+Assign each `record` to the first segment whose assignment interval contains the
+record timestamp.
+
+If a record cannot be assigned:
+
+- Keep it attached to the parent activity.
+- Leave `segment_id = NULL`.
+- Count unassigned records in import metadata.
+
+If a record falls into overlapping segment intervals:
+
+- Prefer the segment with the latest start time.
+- Record the overlap count in import metadata.
+
+### Lap Assignment
+
+Assign each lap to a segment by:
+
+1. Lap `start_time` inside a segment assignment interval.
+2. If lap `start_time` is missing, use FIT message order and lap sport/sub-sport.
+3. If still ambiguous, leave `segment_id = NULL` and keep the lap visible only in
+   the parent view.
+
+As with sessions, do not assume `lap.timestamp` is a reliable end time. Prefer
+`start_time + total_timer_time` or `start_time + total_elapsed_time`.
+
+### Parent Metrics
+
+The parent activity represents the whole multisport recording.
+
+Parent duration priority:
+
+1. FIT activity `total_timer_time`.
+2. Sum of session `total_timer_time`.
+3. Sum of session `total_elapsed_time`.
+4. Existing record-span fallback.
+
+Parent distance priority:
+
+1. FIT activity total distance when available.
+2. Sum of session distances.
+3. Existing record distance fallback.
+
+Parent start/end:
+
+- Start: earliest segment start, or earliest record timestamp.
+- End: latest segment assignment end, or latest record timestamp.
+
+Parent naming:
+
+- Use `Multisport` or a short composed label such as `Bike / Run / Bike`.
+- Do not reverse-geocode the parent from a child GPS leg unless the UI clearly
+  indicates that the location is only from a specific leg.
+
+### Child Naming
+
+Suggested generated names:
+
+- `Bike 1`
+- `T1`
+- `Run`
+- `T2`
+- `Bike 2`
+
+Rules:
+
+- Use sport/sub-sport labels for sport legs.
+- Use `T1`, `T2`, etc. for transitions.
+- Number repeated sport legs.
+- Keep raw FIT sport/sub-sport in metadata.
+
+## API Design
+
+Add segment-aware APIs while preserving existing single-activity endpoints.
+
+Recommended additions:
+
+- `GET /api/activities`
+  - Include `activity_kind`.
+  - Include lightweight child segment summaries for multisport parents, or
+    provide a companion endpoint.
+- `GET /api/activities/{activity_id}/segments`
+  - Returns ordered child segments.
+- `GET /api/activities/{activity_id}/records`
+  - Existing parent behavior.
+  - Add optional `segment_id` query parameter.
+- `GET /api/activities/{activity_id}/laps`
+  - Add or update endpoint to return first-class laps.
+  - Add optional `segment_id` query parameter.
+
+Do not expose child segments as unrelated top-level activity IDs unless the API
+also marks them as children and prevents double-counting.
+
+## UI Design
+
+### Activity List
+
+Show a multisport parent as an expandable row:
+
+```text
+v Multisport - 3h55m - 68.8 km
+    Bike 1 - 1h55m - 40.3 km
+    T1 - 4m52s
+    Run - 52m45s - 8.1 km
+    T2 - 2m50s
+    Bike 2 - 59m56s - 20.2 km
+```
+
+Selection behavior:
+
+- Clicking the parent opens the whole activity.
+- Clicking a child opens the same activity detail page scoped to that segment.
+- Child rows should be indented and visually subordinate.
+- Transition rows should be available but visually de-emphasized.
+
+### Detail Page
+
+Add a compact segment selector near the activity title or existing summary area:
+
+```text
+Entire Activity | Bike 1 | T1 | Run | T2 | Bike 2
+```
+
+When a segment is selected:
+
+- Summary stats use only that segment.
+- Charts use only records assigned to that segment.
+- Map uses only GPS records assigned to that segment.
+- Laps table shows only laps assigned to that segment.
+- Sport-specific calculations use the selected segment sport/sub-sport.
+
+The parent view should show the whole recording, but it should clearly represent
+mixed-sport data. Sport-specific calculations that require a single sport should
+be unavailable or explicitly segment-scoped.
+
+### Maps
+
+For parent multisport view:
+
+- Show all GPS records that exist.
+- Do not imply indoor/no-GPS legs had GPS routes.
+- Consider using subtle segment markers or segment colors once segment route
+  rendering is available.
+
+For child view:
+
+- Show only the selected segment route.
+- If the segment has no GPS, show the normal no-map state.
+
+### Filters
+
+Sport filters should account for child segments:
+
+- Filtering by `running` should match a multisport parent containing a running
+  leg.
+- When the parent is expanded, only matching child rows should be emphasized.
+- Child rows must not add to activity counts in overview totals.
+
+Implementation can start with parent-level inclusion, then add richer child-row
+filter display later.
+
+### Overview Totals
+
+Overview totals should count parent activities only.
+
+Rules:
+
+- A multisport parent contributes one activity count.
+- Parent duration and distance contribute to totals.
+- Child segments do not contribute separately to global totals.
+- Segment-level totals may be shown only in segment-specific drilldowns.
+
+## Compatibility and Migration
+
+- Existing activities remain `activity_kind = single`.
+- Existing records remain `segment_id = NULL`.
+- Existing activity metadata remains valid.
+- New segment/lap tables can be empty for existing imports.
+- Previously imported multisport files should be re-imported to populate segment
+  data unless a migration can reconstruct sessions from stored metadata.
+
+## MVP Scope
+
+Recommended first implementation:
+
+1. Detect multisport FIT files.
+2. Store parent activity plus `activity_segments`.
+3. Assign records to segments.
+4. Store laps in `activity_laps`.
+5. Add API support for listing segments and querying records/laps by segment.
+6. Add activity detail segment selector.
+7. Prevent overview double-counting.
+
+Activity-list expansion, richer sport filtering, and segment-colored map display
+can follow if needed, but the data model should support them from the start.
+
+## Tests
+
+Parser tests:
+
+- Detect `auto_multi_sport` activity type.
+- Import multiple sessions in stable order.
+- Assign records by session `start_time` and duration/boundaries.
+- Do not use repeated or invalid `session.timestamp` as an end time.
+- Assign laps by lap start time and session boundaries.
+- Preserve transition sessions.
+- Preserve indoor/no-GPS legs without borrowing GPS from another leg.
+
+Database tests:
+
+- Parent and child segment rows are stored correctly.
+- Records receive expected `segment_id`.
+- Existing single-sport imports still work.
+- Overview totals count parent multisport activities once.
+
+API/UI tests:
+
+- Parent activity view returns all records/laps.
+- Segment view returns only selected segment records/laps.
+- Map state is correct for GPS and no-GPS segments.
+- Sport-specific calculations are disabled for mixed parent view or scoped to a
+  selected segment.
+
+## Open Questions
+
+- Which FIT activity types beyond `auto_multi_sport` should trigger multisport
+  handling?
+- Should parent names be always `Multisport`, or should they be composed from
+  child sport labels?
+- Should transition distance be included in parent distance exactly as reported
+  by FIT sessions?
+- Should child segments be searchable as separate rows in the activity list, or
+  only visible when the parent is expanded?
+- Should re-import automatically replace an old flattened multisport import, or
+  should users delete and re-import affected files?

--- a/docs/features/multisport-support.md
+++ b/docs/features/multisport-support.md
@@ -12,10 +12,11 @@ legs, for example bike, transition, run, transition, bike. Flattening these into
 one normal activity can make the activity name, map, charts, summary metrics,
 filters, and sport-specific calculations misleading.
 
-The current parser already reads `record`, `session`, and `lap` messages, but the
-database model stores records against only an `activity_id`, stores laps in
-activity metadata JSON, and presents one activity row. There is no first-class
-sub-activity or leg view.
+The current parser already reads `record`, `session`, and `lap` messages, but it
+does not retain a first-class FIT activity summary or a list of session
+summaries. Session fields are folded into one metadata object, records are stored
+against only an `activity_id`, laps are stored in activity metadata JSON, and the
+UI presents one activity row. There is no first-class sub-activity or leg view.
 
 ## Goals
 
@@ -35,6 +36,125 @@ sub-activity or leg view.
   preserve correctness.
 - Adding support for unrelated non-activity FIT file types.
 
+## Before / After Implementation Summary
+
+### Database
+
+Before:
+
+- `activities` stores every import as one top-level activity.
+- `records` rows are linked only by `activity_id`.
+- Laps are stored inside activity `metadata_json`.
+- `delete_activity` removes `records` and then the activity row.
+
+After:
+
+- `activities` remains the parent table, with `activity_kind` (new column)
+  distinguishing `single` from `multisport_parent`.
+- `records` keeps `activity_id` and gains nullable `segment_id` (new column) for
+  multisport record scoping.
+- `activity_segments` (new table) stores one row per FIT session/leg.
+- `activity_laps` (new table) stores first-class lap rows scoped to the parent
+  and, when known, a child segment.
+- Insert, rollback, and delete paths treat records, laps, segments, and the
+  parent activity as one unit.
+
+### Parser
+
+Before:
+
+- `ParsedActivity` exposes one activity summary and one flat record list.
+- FIT `Session` fields are overwritten as the parser sees each session, so
+  multisport files keep only the last session's summary values.
+- FIT `Lap` details are collected into activity metadata JSON, not typed domain
+  structures.
+- FIT `Activity` message fields are not preserved as first-class parent summary
+  data.
+
+After:
+
+- Parser/domain structs (new/expanded) preserve the FIT `activity` message, all
+  `session` messages, all `lap` messages, records, and assignment diagnostics.
+- Session order and lap order are retained before conversion to database rows.
+- Segment boundaries are derived from `session.start_time`, adjacent session
+  starts, and duration fields rather than blindly trusting `session.timestamp`.
+- Existing single-sport parsing still produces the same parent activity and
+  records, with empty segment/lap child tables unless first-class laps are added
+  for all activity types.
+
+### Import Lifecycle
+
+Before:
+
+- Duplicate checks run before import: blacklist, file hash, then exact start/end
+  times.
+- A successful import writes one activity row and its records.
+- If file persistence fails after DB insert, failed-import cleanup calls the
+  existing delete path, which removes records and then the activity row.
+- Deleting an activity removes records and the activity row, then adds the file
+  hash to the blacklist.
+- The current manual reimport workflow is to delete the activity, clear
+  blacklisted hashes in Settings, then upload the file again or run Sync while
+  the source FIT file is still present.
+
+After:
+
+- Duplicate checks remain unchanged: blacklist, file hash, then exact start/end
+  times.
+- A successful multisport import writes the parent activity, `activity_segments`
+  rows (new), `activity_laps` rows (new), and records with `segment_id` (new
+  column).
+- If file persistence fails after DB insert, failed-import cleanup removes all
+  rows for that activity: records, `activity_laps`, `activity_segments`, then the
+  parent activity row.
+- Deleting an activity removes all rows for that activity in the same order, then
+  adds the file hash to the blacklist.
+- The manual reimport workflow remains unchanged. This issue does not add an
+  in-place reimport, replacement, or backfill workflow.
+
+### API and Tauri IPC
+
+Before:
+
+- Web uses `GET /api/records/{activity_id}` for all activity records.
+- Desktop/Tauri uses `get_records(activity_id, resolution_ms)`.
+- There are no first-class segment or lap endpoints/commands.
+
+After:
+
+- Web keeps the existing `GET /api/records/{activity_id}` route and adds
+  optional `segment_id` filtering (new query behavior).
+- Desktop/Tauri `get_records` gets matching optional `segment_id` filtering (new
+  command argument/behavior).
+- `GET /api/activities/{activity_id}/segments` (new endpoint) and matching Tauri
+  command list activity segments.
+- `GET /api/activities/{activity_id}/laps` (new endpoint) and matching Tauri
+  command return first-class laps.
+- Web and desktop adapters expose the same parent/segment semantics to the
+  frontend store.
+
+### Frontend Store and UI
+
+Before:
+
+- `src/stores/activityStore.ts` stores one selected activity and one `records`
+  array for the whole activity.
+- Charts, maps, stats, and insights render the record array they receive.
+- The activity list has one row per imported activity.
+
+After:
+
+- The store keeps one selected parent activity plus optional selected
+  `segment_index` (new state field).
+- The store resolves `segment_index` (new URL/store selection key) to
+  `segment_id` for API calls and scopes its `records` array before rendering.
+- Existing charts, maps, stats, and insights mostly update automatically because
+  they already render the provided record array.
+- MVP UI adds expandable activity-list child rows (new row type/control) for
+  leg selection.
+- The Individual tab layout remains unchanged for both parent and child
+  selections; richer parent/segment detail controls are future enhancement.
+
 ## FIT Observations
 
 An anonymized Garmin multisport sample was inspected for design guidance. It had:
@@ -48,6 +168,18 @@ An anonymized Garmin multisport sample was inspected for design guidance. It had
   had no GPS records.
 - Heart-rate records throughout the legs.
 - Power records in the cycling legs and also in the running leg for this sample.
+- Transition sessions had `sport = transition` and `sub_sport = generic`. They
+  included duration, distance, average speed, total ascent/descent, calories,
+  average/max heart rate, generic cadence, start/end positions, and GPS bounds.
+  They did not include average power or normalized power.
+- Transition records had the same basic movement streams expected from a
+  pedestrian GPS segment: timestamp, distance, speed, altitude/elevation, heart
+  rate, cadence, and GPS for most or all records. In the inspected sample,
+  transition record coverage was:
+  - T1: 75 records, 75 distance, 74 speed, 75 altitude, 75 heart rate, 75
+    cadence, 55 GPS, 0 power.
+  - T2: 46 records, 46 distance, 45 speed, 46 altitude, 46 heart rate, 46
+    cadence, 46 GPS, 0 power.
 
 Important parser nuance: in this sample, the FIT `session.timestamp` and
 `lap.timestamp` values were not usable as segment end times. They repeated the
@@ -55,10 +187,53 @@ parent activity timestamp. The parser must not assume `timestamp` is the end of 
 session or lap. Use `start_time` plus `total_timer_time` or `total_elapsed_time`,
 and use adjacent session starts as assignment boundaries when available.
 
+Garmin Connect presentation reference:
+
+- The multisport parent shows whole-activity summary metrics such as distance,
+  duration, map, and calories.
+- The parent also shows a leg list. Each leg shows activity type, distance, and
+  time, plus sport-specific summary fields where available, such as pace for
+  running and power/watts for cycling.
+- Transition legs are displayed as activity legs. A transition detail view can
+  show distance, time, average speed, total ascent, calories, map, elevation,
+  heart-rate, and performance-condition graphs when those streams exist.
+
 ## Data Model
 
 Keep `activities` as the parent activity table. Add child segments rather than
 creating fake child activities with duplicate file hashes.
+
+These schema additions are compatible with existing databases and single-sport
+data if the implementation includes an automatic additive migration. That
+migration is optional scope for this issue and should be an explicit maintainer
+choice.
+
+Compatibility option:
+
+- A new app binary or Docker container automatically migrates an old DuckDB file
+  during normal startup/schema initialization.
+- Users do not need to wipe the database or run SQL manually.
+- Add the new `activity_kind` and `records.segment_id` columns with `ALTER TABLE
+  ... ADD COLUMN IF NOT EXISTS` during `database.rs::init_schema`, and create the
+  child tables/indexes with `CREATE TABLE IF NOT EXISTS` / `CREATE INDEX IF NOT
+  EXISTS`.
+- Existing rows remain valid with `activity_kind = 'single'` and
+  `records.segment_id = NULL`.
+- If the database does not backfill the default for existing rows, explicitly run:
+
+```sql
+UPDATE activities
+SET activity_kind = 'single'
+WHERE activity_kind IS NULL;
+```
+
+Fresh-database-only option:
+
+- Do not add compatibility migration code.
+- Existing users must wipe the database and reimport activities, or manually
+  alter the database outside the app.
+- This avoids temporary migration baggage in the codebase but makes the feature a
+  breaking upgrade for existing databases.
 
 ### activities
 
@@ -67,9 +242,30 @@ Add fields:
 - `activity_kind VARCHAR DEFAULT 'single'`
   - `single`: current behavior.
   - `multisport_parent`: a parent activity with child segments.
-- `parent_summary_json VARCHAR` or extend existing `metadata_json`
-  - Stores parent-level FIT activity data, raw session summaries, and migration
-    helpers.
+
+Do not add a separate parent summary column for the MVP. Extend the existing
+parent activity `metadata_json` instead. For multisport parents it should store:
+
+- Parent-level FIT activity fields.
+- Raw session and lap summary snapshots needed for troubleshooting.
+- Segment assignment diagnostics.
+
+Metadata compatibility rules:
+
+- Keep existing top-level metadata keys and shapes unchanged. Current frontend
+  code reads `heart_rate_zone_bounds_bpm`, `file_id`, `activity_metrics`,
+  `session`, and `laps` from `metadata_json`.
+- Do not change `session` from the current single-session summary object to an
+  array. Multisport session data should use a new namespaced object instead.
+- Do not change `laps` from the current array shape. First-class lap rows should
+  come from `activity_laps`; debug/source lap snapshots can live under the new
+  multisport namespace.
+- Add multisport-specific metadata under `metadata_json.multisport`, for example
+  `multisport.activity`, `multisport.sessions`, `multisport.laps`, and
+  `multisport.assignment`.
+- Keep the multisport metadata concise. `list_activities` returns
+  `metadata_json` for every activity, so this should store summaries and
+  diagnostics, not full record streams or large raw FIT payloads.
 
 For multisport parents:
 
@@ -109,12 +305,22 @@ Recommended `segment_type` values:
 - `sport`
 - `transition`
 
+`transition` is a supported child segment type for multisport activities. It is
+not treated as a standalone training sport for overview counts, but it should be
+selectable, searchable, and visible as a leg of the parent activity.
+
 Indexes:
 
 ```sql
-CREATE INDEX IF NOT EXISTS idx_activity_segments_activity
+CREATE UNIQUE INDEX IF NOT EXISTS idx_activity_segments_activity_index
     ON activity_segments(activity_id, segment_index);
 ```
+
+Generate `id` values with the same deterministic database-side helper used for
+new activity IDs, such as `SELECT COALESCE(MAX(id), 0) + 1`, or replace both
+with a shared sequence-like allocator if one is introduced. `segment_index` is
+the stable leg identifier within an activity and should remain stable when the
+same FIT file is deleted and imported again.
 
 ### records
 
@@ -162,25 +368,73 @@ CREATE TABLE IF NOT EXISTS activity_laps (
 Indexes:
 
 ```sql
-CREATE INDEX IF NOT EXISTS idx_activity_laps_activity
+CREATE UNIQUE INDEX IF NOT EXISTS idx_activity_laps_activity_index
     ON activity_laps(activity_id, lap_index);
 CREATE INDEX IF NOT EXISTS idx_activity_laps_segment
     ON activity_laps(segment_id, lap_index);
 ```
 
+Generate `id` values with the same child-row ID allocation strategy used for
+`activity_segments`. `lap_index` is global FIT lap message order within the
+parent activity, not a segment-local display number. Segment views can derive a
+separate segment-local lap number after filtering by `segment_id`.
+
+### Lifecycle
+
+The database currently deletes only `records` and `activities` for an activity.
+Once segment and lap tables exist, all activity write paths need to treat the
+parent, segments, laps, and records as one unit:
+
+- Insert parent activity, child segments, first-class laps, and records in one
+  transaction.
+- If an import fails before commit, roll back the transaction.
+- If a caller cannot use the shared transaction boundary, that path must run the
+  same cleanup explicitly: delete records, laps, segments, then the parent
+  activity.
+- On user deletion, delete child rows before the parent activity. The deletion
+  transaction should delete in this order: `records`, `activity_laps`,
+  `activity_segments`, then `activities`. This avoids orphaned telemetry or lap
+  rows even if foreign keys are not enforced.
+- Keep single-sport cleanup unchanged except that empty child tables should not
+  leave orphans.
+
 ## Import and Parser Rules
+
+### Parser Extraction Prerequisites
+
+Before detection and storage can be implemented, the FIT parser needs to preserve
+more source data than it currently exposes through `ParsedActivity`:
+
+- FIT `activity` message fields, including `type`, `total_timer_time`, and
+  activity-level distance when present.
+- Every FIT `session` message in message order, including `sport`, `sub_sport`,
+  `start_time`, `total_timer_time`, `total_elapsed_time`, distance, heart-rate,
+  cadence, calories, and transition indicators. The current parser overwrites
+  session-scoped local variables on each `Session` message, so multisport files
+  lose all but the last session's summary fields unless this is changed.
+- Every FIT `lap` message in message order, including `sport` and `sub_sport`
+  when present.
+- Segment assignment metadata, including unassigned and overlapping record/lap
+  counts.
+
+This should be represented in parser/domain structs first, then converted into
+database rows. Previously imported metadata should not be assumed to contain
+enough session detail for reconstruction.
 
 ### Detection
 
 Treat a FIT file as multisport when:
 
-1. The FIT `activity.type` is `auto_multi_sport` or another recognized
-   multisport activity type.
+1. The FIT `activity.type` is `auto_multi_sport`.
 2. Or the file contains more than one FIT `session` with distinct session start
-   times and at least one sport transition.
+   times and either:
+   - at least one FIT session whose sport is `transition`;
+   - or a sport/sub-sport change between adjacent non-transition sessions.
 
 Condition 1 is the strongest signal. Condition 2 is a fallback for compatible
-files that encode multiple sessions without the expected activity type.
+files that encode multiple sessions without the expected activity type. Do not
+broaden detection to additional FIT activity types until a real file or SDK enum
+case is identified.
 
 ### Segment Ordering
 
@@ -208,13 +462,23 @@ For each session:
 Use half-open intervals `[start, end)` for assigning records and laps. This
 prevents boundary samples from being double-counted.
 
+Record/lap assignment intentionally uses the next session start before declared
+duration-derived ends. That keeps all timeline samples inside a deterministic
+segment when devices report timer or elapsed durations differently from the
+record stream. The stored segment `timer_duration_s` and `elapsed_duration_s`
+still come from the FIT session summaries. If records extend past
+`segment_elapsed_end` or `segment_timer_end` before the next session starts,
+count them in segment assignment diagnostics, but do not leave them unassigned
+solely for that reason.
+
 Do not use `session.timestamp` as the end time unless validation shows it is
 later than `start_time` and consistent with the session duration.
 
 ### Record Assignment
 
-Assign each `record` to the first segment whose assignment interval contains the
-record timestamp.
+Assign each `record` to matching segments by timestamp. If exactly one segment
+assignment interval contains the record timestamp, use that segment. If more than
+one interval matches, use the overlapping-record rule below.
 
 If a record cannot be assigned:
 
@@ -253,8 +517,13 @@ Parent duration priority:
 Parent distance priority:
 
 1. FIT activity total distance when available.
-2. Sum of session distances.
+2. Sum of session distances, including transition session distance exactly as the
+   FIT file reports it.
 3. Existing record distance fallback.
+
+Including transition distance keeps the parent summary aligned with the FIT
+activity's whole-recording distance. Sport-specific distance summaries should be
+read from the selected child segment instead.
 
 Parent start/end:
 
@@ -263,9 +532,9 @@ Parent start/end:
 
 Parent naming:
 
-- Use `Multisport` or a short composed label such as `Bike / Run / Bike`.
-- Do not reverse-geocode the parent from a child GPS leg unless the UI clearly
-  indicates that the location is only from a specific leg.
+- Always use `Multisport` for the parent activity name.
+- Do not reverse-geocode the parent from a child GPS leg.
+- Child segment names carry the sport-specific context.
 
 ### Child Naming
 
@@ -283,6 +552,11 @@ Rules:
 - Use `T1`, `T2`, etc. for transitions.
 - Number repeated sport legs.
 - Keep raw FIT sport/sub-sport in metadata.
+- Keep `transition` as `segment_type = transition`; do not convert it into a
+  normal sport activity.
+- Add translation keys for visible labels such as `Multisport`, `Entire
+  Activity`, sport/sub-sport display names, and transition labels. Do not hardcode
+  English-only UI strings.
 
 ## API Design
 
@@ -296,12 +570,40 @@ Recommended additions:
     provide a companion endpoint.
 - `GET /api/activities/{activity_id}/segments`
   - Returns ordered child segments.
-- `GET /api/activities/{activity_id}/records`
-  - Existing parent behavior.
-  - Add optional `segment_id` query parameter.
+- `GET /api/records/{activity_id}`
+  - Preserve the existing route and parent behavior.
+  - Add optional `segment_id` query parameter, or add
+    `GET /api/activities/{activity_id}/records` as a compatibility alias.
+  - The implementation should extend the current `records_downsampled` query to
+    conditionally filter by `segment_id` before downsampling.
 - `GET /api/activities/{activity_id}/laps`
-  - Add or update endpoint to return first-class laps.
+  - Add an endpoint to return first-class laps.
   - Add optional `segment_id` query parameter.
+
+Tauri IPC must get matching command support, because the frontend uses Tauri
+commands in desktop mode and HTTP endpoints in web mode. Add or update commands
+such as `list_activity_segments`, `get_records`, and `get_activity_laps` with
+the same parent and `segment_id` semantics as the web API. The frontend `api`
+adapter and activity store should expose segment-aware selection without making
+web and desktop behavior diverge.
+
+Frontend state should keep one selected display row: either the multisport
+parent or a child segment row. Child row selection should retain the parent
+`activity_id` plus an optional selected `segment_index`. In web mode, encode
+child selection in the activity detail URL as `?segment_index=<index>` and omit
+the parameter for the parent view. Resolve `segment_index` to the current row
+`segment_id` internally when calling record and lap APIs. This keeps deep links
+stable if the same FIT file is deleted and imported again, because database row
+IDs may change while FIT session order does not. Desktop/Tauri state should use
+the same shape even if it is not represented by an HTTP URL.
+
+For the first pass, keep the Individual tab display model unchanged. The existing
+frontend already centralizes selected activity records in
+`src/stores/activityStore.ts`; scope that store's `records` array only when a
+child segment row is selected. Charts, maps, stats panels, and laps should then
+render exactly as they do today, using either the full parent activity data or
+the selected child segment data. Do not add a separate detail-page segment
+selector or custom parent-detail layout in the first pass.
 
 Do not expose child segments as unrelated top-level activity IDs unless the API
 also marks them as children and prevents double-counting.
@@ -310,43 +612,54 @@ also marks them as children and prevents double-counting.
 
 ### Activity List
 
-Show a multisport parent as an expandable row:
+Target UX: show a multisport parent as an expandable row:
 
 ```text
-v Multisport - 3h55m - 68.8 km
-    Bike 1 - 1h55m - 40.3 km
-    T1 - 4m52s
-    Run - 52m45s - 8.1 km
-    T2 - 2m50s
-    Bike 2 - 59m56s - 20.2 km
+v Multisport - 3h55m - 68.8 km - calories if available
+    Bike 1 - 1h55m - 40.3 km - power/watts if available
+    T1 - 4m52s - distance/calories if available
+    Run - 52m45s - 8.1 km - pace if available
+    T2 - 2m50s - distance/calories if available
+    Bike 2 - 59m56s - 20.2 km - power/watts if available
 ```
 
 Selection behavior:
 
-- Clicking the parent opens the whole activity.
+- Clicking the parent opens the whole activity with no segment selected.
 - Clicking a child opens the same activity detail page scoped to that segment.
+- In web mode, child selection should preserve the parent activity route and add
+  `?segment_index=<index>` so refresh, browser history, and shared links keep the
+  same scoped view.
 - Child rows should be indented and visually subordinate.
-- Transition rows should be available but visually de-emphasized.
+- Transition rows should be available, searchable, selectable, and visually
+  de-emphasized.
 
 ### Detail Page
 
-Add a compact segment selector near the activity title or existing summary area:
+First-pass UX: do not change the Individual tab layout. The activity list is the
+only required place to choose between the parent and child legs.
 
-```text
-Entire Activity | Bike 1 | T1 | Run | T2 | Bike 2
-```
+When the parent is selected, the existing Individual tab should render the whole
+activity using the same layout as any other activity. Summary stats, charts,
+map, and laps use the full parent activity data. Sport-specific calculations
+that require one coherent sport/output stream may be unavailable for the parent,
+or may be limited to calculations that are valid on mixed-sport data.
 
-When a segment is selected:
+When a child row is selected, the existing Individual tab should render the
+selected leg using the same layout as any other activity. Summary stats, charts,
+map, laps, and sport-specific calculations use only that segment's data.
 
-- Summary stats use only that segment.
-- Charts use only records assigned to that segment.
-- Map uses only GPS records assigned to that segment.
-- Laps table shows only laps assigned to that segment.
-- Sport-specific calculations use the selected segment sport/sub-sport.
+Transition segment detail should also reuse the same Individual tab layout where
+data exists. Treat transitions as generic GPS movement segments, similar to a
+walking/running-style activity for display purposes but without assuming
+running-specific fields. Show generic fields and streams such as distance,
+duration/time, speed or pace, total ascent, calories, map, elevation, heart rate,
+and cadence when available. Do not expect power or normalized power on transition
+segments, and hide or disable sport-specific calculations that do not apply.
 
-The parent view should show the whole recording, but it should clearly represent
-mixed-sport data. Sport-specific calculations that require a single sport should
-be unavailable or explicitly segment-scoped.
+Future enhancement: add a richer multisport parent view, detail-page segment
+selector, per-leg summary strip, segment-colored route overlays, or Garmin
+Connect-style parent presentation after the first pass is working.
 
 ### Maps
 
@@ -368,11 +681,13 @@ Sport filters should account for child segments:
 
 - Filtering by `running` should match a multisport parent containing a running
   leg.
-- When the parent is expanded, only matching child rows should be emphasized.
+- Child segments should also be searchable/filterable as separate activity-list
+  rows.
+- When the parent is expanded, matching child rows should be emphasized.
 - Child rows must not add to activity counts in overview totals.
 
-Implementation can start with parent-level inclusion, then add richer child-row
-filter display later.
+Implementation can start with parent-level inclusion for the MVP, but the target
+activity-list behavior includes searchable child segment rows.
 
 ### Overview Totals
 
@@ -387,35 +702,59 @@ Rules:
 
 ## Compatibility and Migration
 
-- Existing activities remain `activity_kind = single`.
-- Existing records remain `segment_id = NULL`.
-- Existing activity metadata remains valid.
+- Automatic migration of existing databases is optional scope. If included, app
+  startup/schema initialization migrates existing databases without a user DB
+  wipe or manual SQL.
+- If automatic migration is not included, this is a fresh-database-only/breaking
+  upgrade and existing users must wipe and reimport or manually alter the DB.
+- With migration, existing activities remain `activity_kind = single`.
+- With migration, existing records remain `segment_id = NULL`.
+- Existing activity metadata remains valid because multisport metadata is added
+  under a new `multisport` namespace and existing top-level metadata keys keep
+  their current shapes.
 - New segment/lap tables can be empty for existing imports.
-- Previously imported multisport files should be re-imported to populate segment
-  data unless a migration can reconstruct sessions from stored metadata.
+- Previously imported multisport files cannot be reliably reconstructed from the
+  current metadata format, because only one folded session summary is stored.
+- This issue does not add an in-place reimport, replacement, or backfill workflow.
+- To update an already imported activity with the new parser behavior, users can
+  use the current manual pathway: delete the activity, clear blacklisted hashes
+  in Settings, then upload the file again or run Sync while the source file is
+  still present.
+- Sync-file imports currently skip blacklisted hashes and duplicate file hashes
+  before parsing. That is unchanged by this issue.
 
 ## MVP Scope
 
 Recommended first implementation:
 
-1. Detect multisport FIT files.
-2. Store parent activity plus `activity_segments`.
-3. Assign records to segments.
-4. Store laps in `activity_laps`.
-5. Add API support for listing segments and querying records/laps by segment.
-6. Add activity detail segment selector.
-7. Prevent overview double-counting.
+1. Extend parser/domain structs to capture FIT activity, all sessions, all laps,
+   and segment assignment metadata.
+2. Detect multisport FIT files.
+3. Store parent activity plus `activity_segments`.
+4. Assign records to segments.
+5. Store laps in `activity_laps`.
+6. Update insert, rollback, and delete cleanup for segments and laps.
+7. Add web API and Tauri IPC support for listing segments and querying records
+   and laps by segment.
+8. Add activity detail segment selector.
+9. Prevent overview double-counting.
 
-Activity-list expansion, richer sport filtering, and segment-colored map display
-can follow if needed, but the data model should support them from the start.
+The MVP should include the detail-page segment selector. Activity-list expansion,
+searchable child segment rows, richer sport filtering, and segment-colored map
+display are target UX and can follow later, but the data model should support
+them from the start.
 
 ## Tests
 
 Parser tests:
 
 - Detect `auto_multi_sport` activity type.
+- Preserve all FIT session summaries instead of only the last session seen.
+- Preserve FIT activity-level totals used for parent duration and distance.
 - Import multiple sessions in stable order.
 - Assign records by session `start_time` and duration/boundaries.
+- Assign overlapping records to the matching segment with the latest start time
+  and count the overlap in diagnostics.
 - Do not use repeated or invalid `session.timestamp` as an end time.
 - Assign laps by lap start time and session boundaries.
 - Preserve transition sessions.
@@ -424,7 +763,10 @@ Parser tests:
 Database tests:
 
 - Parent and child segment rows are stored correctly.
+- Segment and lap indexes prevent duplicate child rows for the same activity.
 - Records receive expected `segment_id`.
+- Activity deletion and import rollback remove records, laps, segments, and the
+  parent in the documented cleanup order.
 - Existing single-sport imports still work.
 - Overview totals count parent multisport activities once.
 
@@ -432,19 +774,11 @@ API/UI tests:
 
 - Parent activity view returns all records/laps.
 - Segment view returns only selected segment records/laps.
+- Web detail URLs preserve optional `segment_index` selection across refresh and
+  browser navigation.
+- Web API and Tauri IPC return matching segment, record, and lap data.
 - Map state is correct for GPS and no-GPS segments.
 - Sport-specific calculations are disabled for mixed parent view or scoped to a
   selected segment.
-
-## Open Questions
-
-- Which FIT activity types beyond `auto_multi_sport` should trigger multisport
-  handling?
-- Should parent names be always `Multisport`, or should they be composed from
-  child sport labels?
-- Should transition distance be included in parent distance exactly as reported
-  by FIT sessions?
-- Should child segments be searchable as separate rows in the activity list, or
-  only visible when the parent is expanded?
-- Should re-import automatically replace an old flattened multisport import, or
-  should users delete and re-import affected files?
+- Target activity-list UX can search/filter child segment rows, including
+  transition rows, without double-counting them in overview totals.

--- a/docs/features/multisport-support.md
+++ b/docs/features/multisport-support.md
@@ -28,10 +28,30 @@ UI presents one activity row. There is no first-class sub-activity or leg view.
 - Prevent child legs from being double-counted in overview totals.
 - Keep existing single-sport activity behavior unchanged.
 
+## File Format Scope
+
+First-pass multisport support is FIT-only.
+
+Garmin Connect exports the multisport parent activity as a FIT file. When an
+individual multisport leg is selected in Garmin Connect, downloading FIT still
+returns the same full parent multisport FIT payload. In the inspected sample, FIT
+files downloaded from each selected leg had different Garmin activity-id
+filenames but identical file hashes and identical parent multisport content.
+
+Garmin Connect can export selected legs as TCX or GPX, but those files represent
+only that selected leg, not the multisport parent. TCX preserved the full selected
+leg duration in the inspected transition export. GPX preserved only the GPS track
+portion of that selected leg and omitted an initial no-GPS portion. Therefore,
+this feature does not attempt to support parent multisport GPX or TCX imports.
+
+Existing single-sport GPX and TCX import behavior is unchanged. A separate TCX
+distance issue was filed as #29 and is outside this multisport scope.
+
 ## Non-Goals
 
 - Splitting a multisport FIT file into unrelated standalone activities.
 - Supporting manual editing of leg boundaries in the first implementation.
+- Supporting multisport GPX or TCX imports.
 - Rewriting all chart and statistics code in one step if a narrower MVP can
   preserve correctness.
 - Adding support for unrelated non-activity FIT file types.
@@ -54,10 +74,10 @@ After:
 - `records` keeps `activity_id` and gains nullable `segment_id` (new column) for
   multisport record scoping.
 - `activity_segments` (new table) stores one row per FIT session/leg.
-- `activity_laps` (new table) stores first-class lap rows scoped to the parent
-  and, when known, a child segment.
-- Insert, rollback, and delete paths treat records, laps, segments, and the
-  parent activity as one unit.
+- Laps remain in `metadata_json.laps` for the first pass, with added segment
+  assignment fields when known. `activity_laps` is deferred/future scope.
+- Insert, rollback, and delete paths treat records, segment-tagged lap metadata,
+  segments, and the parent activity as one unit.
 
 ### Parser
 
@@ -78,9 +98,8 @@ After:
 - Session order and lap order are retained before conversion to database rows.
 - Segment boundaries are derived from `session.start_time`, adjacent session
   starts, and duration fields rather than blindly trusting `session.timestamp`.
-- Existing single-sport parsing still produces the same parent activity and
-  records, with empty segment/lap child tables unless first-class laps are added
-  for all activity types.
+- Existing single-sport parsing still produces the same parent activity,
+  records, and metadata-backed laps.
 
 ### Import Lifecycle
 
@@ -102,11 +121,11 @@ After:
 - Duplicate checks remain unchanged: blacklist, file hash, then exact start/end
   times.
 - A successful multisport import writes the parent activity, `activity_segments`
-  rows (new), `activity_laps` rows (new), and records with `segment_id` (new
-  column).
+  rows (new), segment-tagged laps in `metadata_json.laps`, and records with
+  `segment_id` (new column).
 - If file persistence fails after DB insert, failed-import cleanup removes all
-  rows for that activity: records, `activity_laps`, `activity_segments`, then the
-  parent activity row.
+  rows for that activity: records, `activity_segments`, then the parent activity
+  row. Segment-tagged lap metadata is removed with the parent row.
 - Deleting an activity removes all rows for that activity in the same order, then
   adds the file hash to the blacklist.
 - The manual reimport workflow remains unchanged. This issue does not add an
@@ -128,8 +147,8 @@ After:
   command argument/behavior).
 - `GET /api/activities/{activity_id}/segments` (new endpoint) and matching Tauri
   command list activity segments.
-- `GET /api/activities/{activity_id}/laps` (new endpoint) and matching Tauri
-  command return first-class laps.
+- First-pass laps stay in activity metadata. The existing activity payload carries
+  `metadata_json.laps`, and child views filter those laps by selected segment.
 - Web and desktop adapters expose the same parent/segment semantics to the
   frontend store.
 
@@ -257,9 +276,9 @@ Metadata compatibility rules:
   `session`, and `laps` from `metadata_json`.
 - Do not change `session` from the current single-session summary object to an
   array. Multisport session data should use a new namespaced object instead.
-- Do not change `laps` from the current array shape. First-class lap rows should
-  come from `activity_laps`; debug/source lap snapshots can live under the new
-  multisport namespace.
+- Do not change `laps` from the current array shape. First-pass lap display
+  remains backed by `metadata_json.laps`; debug/source lap snapshots can live
+  under the new multisport namespace.
 - Add multisport-specific metadata under `metadata_json.multisport`, for example
   `multisport.activity`, `multisport.sessions`, `multisport.laps`, and
   `multisport.assignment`.
@@ -338,8 +357,14 @@ should keep their parent `activity_id` and also receive the matching
 
 ### laps
 
-The existing importer stores laps inside `metadata_json`. Multisport needs laps
-to be scoped to a selected leg, so add a first-class lap table:
+The existing importer stores laps inside `metadata_json`. For the first pass, keep
+that storage model and add segment assignment fields to the existing lap metadata
+objects when known. Parent views read all metadata-backed laps. Child views filter
+`metadata_json.laps` by selected `segment_index`. Ambiguous laps remain visible
+only on the parent view.
+
+Future scope: add a first-class lap table if metadata-backed laps become too
+awkward or if a general lap API is added for all activity types:
 
 ```sql
 CREATE TABLE IF NOT EXISTS activity_laps (
@@ -382,21 +407,21 @@ separate segment-local lap number after filtering by `segment_id`.
 ### Lifecycle
 
 The database currently deletes only `records` and `activities` for an activity.
-Once segment and lap tables exist, all activity write paths need to treat the
-parent, segments, laps, and records as one unit:
+With first-pass segment support, activity write paths need to treat the parent,
+segments, segment-tagged lap metadata, and records as one unit:
 
-- Insert parent activity, child segments, first-class laps, and records in one
-  transaction.
+- Insert parent activity, child segments, segment-tagged lap metadata, and
+  records in one transaction.
 - If an import fails before commit, roll back the transaction.
 - If a caller cannot use the shared transaction boundary, that path must run the
-  same cleanup explicitly: delete records, laps, segments, then the parent
-  activity.
+  same cleanup explicitly: delete records, segments, then the parent activity.
 - On user deletion, delete child rows before the parent activity. The deletion
-  transaction should delete in this order: `records`, `activity_laps`,
-  `activity_segments`, then `activities`. This avoids orphaned telemetry or lap
-  rows even if foreign keys are not enforced.
+  transaction should delete in this order: `records`, `activity_segments`, then
+  `activities`. This avoids orphaned telemetry rows even if foreign keys are not
+  enforced. Segment-tagged lap metadata is removed with the parent activity row.
 - Keep single-sport cleanup unchanged except that empty child tables should not
-  leave orphans.
+  leave orphans. Future `activity_laps` work must add lap-row cleanup to the same
+  transaction.
 
 ## Import and Parser Rules
 
@@ -576,14 +601,15 @@ Recommended additions:
     `GET /api/activities/{activity_id}/records` as a compatibility alias.
   - The implementation should extend the current `records_downsampled` query to
     conditionally filter by `segment_id` before downsampling.
-- `GET /api/activities/{activity_id}/laps`
-  - Add an endpoint to return first-class laps.
-  - Add optional `segment_id` query parameter.
+- First-pass laps remain in activity metadata. The frontend should filter
+  `metadata_json.laps` by selected `segment_index` for child views. A dedicated
+  laps endpoint is deferred until first-class `activity_laps` exists.
 
 Tauri IPC must get matching command support, because the frontend uses Tauri
 commands in desktop mode and HTTP endpoints in web mode. Add or update commands
-such as `list_activity_segments`, `get_records`, and `get_activity_laps` with
-the same parent and `segment_id` semantics as the web API. The frontend `api`
+such as `list_activity_segments` and `get_records` with the same parent and
+`segment_id` semantics as the web API. First-pass lap filtering uses activity
+metadata. The frontend `api`
 adapter and activity store should expose segment-aware selection without making
 web and desktop behavior diverge.
 
@@ -700,6 +726,21 @@ Rules:
 - Child segments do not contribute separately to global totals.
 - Segment-level totals may be shown only in segment-specific drilldowns.
 
+## Export and Compare
+
+- Existing single-sport export and compare behavior should remain unchanged.
+- Export is supported for a selected child leg by using segment-scoped records in
+  the existing export shape. A child leg is a coherent single-sport view and is
+  the safest first-pass export target.
+- Multisport parent export is deferred. Parent records mix sports, output
+  streams, and segment semantics, so parent export needs a deliberate
+  multisport-specific shape before it is exposed.
+- Multisport compare behavior is not designed in the first pass. Preserve
+  existing single-sport compare behavior, but do not add special parent or child
+  multisport compare support in this slice.
+- Future work should treat parent compare and child-leg compare as separate
+  design tasks.
+
 ## Compatibility and Migration
 
 - Automatic migration of existing databases is optional scope. If included, app
@@ -712,7 +753,8 @@ Rules:
 - Existing activity metadata remains valid because multisport metadata is added
   under a new `multisport` namespace and existing top-level metadata keys keep
   their current shapes.
-- New segment/lap tables can be empty for existing imports.
+- New segment tables can be empty for existing imports. First-pass lap data
+  remains metadata-backed.
 - Previously imported multisport files cannot be reliably reconstructed from the
   current metadata format, because only one folded session summary is stored.
 - This issue does not add an in-place reimport, replacement, or backfill workflow.
@@ -732,10 +774,10 @@ Recommended first implementation:
 2. Detect multisport FIT files.
 3. Store parent activity plus `activity_segments`.
 4. Assign records to segments.
-5. Store laps in `activity_laps`.
-6. Update insert, rollback, and delete cleanup for segments and laps.
+5. Store segment-tagged laps in `metadata_json.laps`.
+6. Update insert, rollback, and delete cleanup for segments and parent metadata.
 7. Add web API and Tauri IPC support for listing segments and querying records
-   and laps by segment.
+   by segment; filter metadata-backed laps by selected segment.
 8. Add activity detail segment selector.
 9. Prevent overview double-counting.
 


### PR DESCRIPTION
Closes #21.

## Summary

This PR is a design proposal only. It adds a documentation package for supporting Garmin multisport activities without implementing the feature yet.

The proposal is split into three docs:

- `docs/features/multisport-support.md`
  - Main design/source of truth.
  - Defines first-pass scope, Garmin Connect export findings, FIT-only parent detection, data model, import/parser rules, UI behavior, overview aggregation, export/compare policy, compatibility, MVP scope, and tests.
- `docs/features/multisport-implementation-plan.md`
  - Ordered implementation plan.
  - Breaks the design into backend parser/domain work, fresh schema support, insert/delete/rollback, segment APIs, frontend state, activity-list rows, Individual tab reuse, Overview guardrails, export behavior, and deferred migration.
- `docs/features/multisport-deferred.md`
  - Future/deferred scope parking lot.
  - Tracks items intentionally excluded from the first slice, including parent multisport export, parent compare, child-leg compare, richer parent views, URL state, first-class lap tables, automatic migration, and test fixture work.

## Key design decisions

- First-pass multisport parent support is FIT-only.
- Garmin Connect FIT downloads from selected legs can still contain the same full parent multisport FIT payload.
- Garmin Connect TCX/GPX downloads from selected legs are ordinary single-leg exports, not parent multisport exports.
- TCX/GPX should not enter multisport parent detection.
- TCX distance correction is tracked separately in #29 and is outside this scope.
- Child legs are selectable from expandable activity-list parent rows.
- Child-leg export is in first-slice scope using segment-scoped records and the existing export shape.
- Multisport parent export is deferred until a deliberate parent export shape is designed.
- Multisport compare behavior is not designed in the first pass; parent compare and child-leg compare are deferred separately.
- First pass keeps laps in `metadata_json.laps` with segment assignment fields; `activity_laps` is deferred.
- Automatic database migration is deferred; first implementation targets a fresh schema.

## Testing

Documentation-only PR. No code or runtime behavior changed.
