### PR TITLE
Fix non-GPS activity names from parsed type

### DIFF
--- a/src-tauri/src/fit_parser.rs
+++ b/src-tauri/src/fit_parser.rs
@@ -148,20 +148,78 @@ fn child_node<'a>(node: roxmltree::Node<'a, 'a>, name: &str) -> Option<roxmltree
         .find(|n| n.is_element() && n.tag_name().name() == name)
 }
 
-fn title_case_sport(sport: &str) -> String {
-    if sport.is_empty() {
-        return "Activity".to_string();
-    }
-    let mut chars = sport.chars();
-    let Some(first) = chars.next() else {
-        return "Activity".to_string();
-    };
-    first.to_uppercase().collect::<String>() + chars.as_str()
+fn title_case_words(value: &str) -> String {
+    let words: Vec<String> = value
+        .split(|c: char| c == '_' || c == '-' || c.is_whitespace())
+        .filter(|part| !part.is_empty())
+        .map(|part| {
+            let lower = part.to_lowercase();
+            let mut chars = lower.chars();
+            match chars.next() {
+                Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+                None => String::new(),
+            }
+        })
+        .filter(|part| !part.is_empty())
+        .collect();
+
+    words.join(" ")
 }
 
-fn build_activity_name(file_name: &str, sport: &str, points: &[RecordPoint]) -> String {
-    let fallback = strip_known_extension(file_name);
+fn title_case_sport(sport: &str) -> String {
+    let sport = sport.trim();
+    if sport.is_empty() || sport.eq_ignore_ascii_case("unknown") {
+        return "Activity".to_string();
+    }
+
+    let label = title_case_words(sport);
+    if label.is_empty() {
+        "Activity".to_string()
+    } else {
+        label
+    }
+}
+
+fn activity_type_label(sport: &str, sub_sport: Option<&str>) -> String {
     let sport_label = title_case_sport(sport);
+    let Some(raw_sub_sport) = sub_sport.map(str::trim).filter(|s| !s.is_empty()) else {
+        return sport_label;
+    };
+
+    let sub_sport_lower = raw_sub_sport.to_lowercase();
+    if matches!(sub_sport_lower.as_str(), "generic" | "all" | "unknown" | "invalid") {
+        return sport_label;
+    }
+
+    if matches!(sub_sport_lower.as_str(), "indoor_cycling" | "spin") {
+        return "Indoor Cycling".to_string();
+    }
+
+    let sub_sport_label = title_case_words(raw_sub_sport);
+    if sub_sport_label.is_empty() {
+        return sport_label;
+    }
+
+    let sport_lower = sport.trim().to_lowercase();
+    if sport_label == "Activity" || sub_sport_lower.contains(sport_lower.as_str()) {
+        sub_sport_label
+    } else {
+        format!("{sub_sport_label} {sport_label}")
+    }
+}
+
+fn generated_activity_name(sport: &str, sub_sport: Option<&str>) -> String {
+    activity_type_label(sport, sub_sport)
+}
+
+fn build_activity_name(
+    file_name: &str,
+    sport: &str,
+    sub_sport: Option<&str>,
+    points: &[RecordPoint],
+) -> String {
+    let fallback = strip_known_extension(file_name);
+    let activity_label = generated_activity_name(sport, sub_sport);
 
     if let Some(pos) = points.iter().find(|p| p.latitude.is_some() && p.longitude.is_some()) {
         let geocoder = reverse_geocoder::ReverseGeocoder::new();
@@ -176,9 +234,13 @@ fn build_activity_name(file_name: &str, sport: &str, points: &[RecordPoint]) -> 
             loc_parts.push(record.admin1.as_str());
         }
         let loc = loc_parts.join(", ");
-        if !loc.is_empty() {
-            return format!("{} — {}", loc, sport_label);
+        if !loc.is_empty() && activity_label != "Activity" {
+            return format!("{} — {}", loc, activity_label);
         }
+    }
+
+    if activity_label != "Activity" {
+        return activity_label;
     }
 
     fallback
@@ -286,6 +348,7 @@ fn parse_fit_bytes(file_name: &str, bytes: &[u8]) -> Result<ParsedActivity> {
 
     let mut points: Vec<RecordPoint> = Vec::new();
     let mut sport = String::from("unknown");
+    let mut sub_sport: Option<String> = None;
     let mut device = String::new();
     let mut file_id_product_name: Option<String> = None;
     let mut file_id_manufacturer: Option<String> = None;
@@ -377,6 +440,12 @@ fn parse_fit_bytes(file_name: &str, bytes: &[u8]) -> Result<ParsedActivity> {
             for field in rec.fields() {
                 match field.name() {
                     "sport" => sport = value_string(field.value()).to_lowercase(),
+                    "sub_sport" => {
+                        let value = value_string(field.value()).to_lowercase();
+                        if !value.trim().is_empty() {
+                            sub_sport = Some(value);
+                        }
+                    }
                     "beginning_body_battery" | "start_body_battery" => {
                         session_beginning_body_battery = value_i64(field.value())
                     }
@@ -639,6 +708,7 @@ fn parse_fit_bytes(file_name: &str, bytes: &[u8]) -> Result<ParsedActivity> {
         "record_count": points.len(),
         "device": device,
         "sport": sport,
+        "sub_sport": sub_sport.as_deref(),
         "source_format": "fit",
         "file_id": {
             "product_name": file_id_combined_name,
@@ -669,7 +739,7 @@ fn parse_fit_bytes(file_name: &str, bytes: &[u8]) -> Result<ParsedActivity> {
     })
     .to_string();
 
-    let activity_name = build_activity_name(file_name, &sport, &points);
+    let activity_name = build_activity_name(file_name, &sport, sub_sport.as_deref(), &points);
 
     Ok(ParsedActivity {
         file_name: file_name.to_string(),
@@ -809,7 +879,7 @@ fn parse_tcx_bytes(file_name: &str, bytes: &[u8]) -> Result<ParsedActivity> {
     })
     .to_string();
 
-    let activity_name = build_activity_name(file_name, &sport, &points);
+    let activity_name = build_activity_name(file_name, &sport, None, &points);
 
     Ok(ParsedActivity {
         file_name: file_name.to_string(),
@@ -956,7 +1026,7 @@ fn parse_gpx_bytes(file_name: &str, bytes: &[u8]) -> Result<ParsedActivity> {
     })
     .to_string();
 
-    let activity_name = build_activity_name(file_name, &sport, &points);
+    let activity_name = build_activity_name(file_name, &sport, None, &points);
 
     Ok(ParsedActivity {
         file_name: file_name.to_string(),
@@ -978,4 +1048,43 @@ fn parse_gpx_bytes(file_name: &str, bytes: &[u8]) -> Result<ParsedActivity> {
         records: points,
         metadata_json,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn uses_indoor_sub_sport_for_non_gps_name() {
+        let name = build_activity_name(
+            "123456789_987654321.fit",
+            "cycling",
+            Some("indoor_cycling"),
+            &[],
+        );
+
+        assert_eq!(name, "Indoor Cycling");
+    }
+
+    #[test]
+    fn uses_activity_type_for_non_gps_even_with_meaningful_filename() {
+        let name = build_activity_name("Lunch Ride.fit", "cycling", None, &[]);
+
+        assert_eq!(name, "Cycling");
+    }
+
+    #[test]
+    fn falls_back_to_filename_when_activity_type_is_unknown() {
+        let name = build_activity_name("Lunch Ride.fit", "unknown", None, &[]);
+
+        assert_eq!(name, "Lunch Ride");
+    }
+
+    #[test]
+    fn builds_readable_activity_type_labels() {
+        assert_eq!(activity_type_label("cycling", Some("indoor_cycling")), "Indoor Cycling");
+        assert_eq!(activity_type_label("cycling", Some("spin")), "Indoor Cycling");
+        assert_eq!(activity_type_label("cycling", Some("road")), "Road Cycling");
+        assert_eq!(activity_type_label("unknown", Some("generic")), "Activity");
+    }
 }


### PR DESCRIPTION
## Summary

Fix activity naming so non-GPS imports use the parsed activity type instead of falling back to generated Garmin download/export filenames.

This removes the dependency on recognizing specific generated filename patterns and makes naming deterministic from parsed activity metadata whenever that metadata is usable.

## Naming behavior

1. If the imported activity has at least one GPS coordinate
   - Use reverse-geocoded location plus parsed activity type.
   - FIT: `Location — useful sub-sport label`, otherwise `Location — sport label`.
   - TCX: `Location — sport label`.
   - GPX: `Location — type/sport label`.

2. If the imported activity has no GPS coordinates
   - Use parsed activity type.
   - FIT: useful sub-sport label if present, otherwise sport label.
   - TCX: sport label.
   - GPX: not currently applicable, because metadata-only/no-trackpoint GPX is rejected.

3. Use stripped filename only if parsed activity type is unusable
   - "Unusable" means the parsed sport/type label resolves to `Activity`.
   - That happens when sport/type is missing, empty, unknown, or otherwise cannot produce a label.
   - It does not depend on whether the filename looks generated.

## Implementation notes

- Adds FIT `sub_sport` parsing for activity naming and metadata.
- Treats generic/unknown sub-sport values as unusable and falls back to sport.
- Keeps filename fallback for truly unknown activity type metadata.
- Adds parser unit tests for non-GPS naming and unknown activity fallback.

Closes #16.
This PR replaces #14 which upon further analysis was incomplete. 

## Tests

```text
cargo test --manifest-path /work/src-tauri/Cargo.toml -j1
```

Passed in the constrained local Rust test container.
