### PR TITLE
Add distance x-axis option to telemetry charts

### DIFF
--- a/docs/features/chart-distance-axis.md
+++ b/docs/features/chart-distance-axis.md
@@ -1,0 +1,161 @@
+# Individual Chart Distance Axis Design
+
+## Summary
+
+Add a control on the Individual page that lets users switch eligible telemetry charts between a Time x-axis and a Distance x-axis.
+
+This feature applies only to time-based telemetry line charts. The effort heatmap is excluded because it is intentionally binned by elapsed minutes rather than plotted as point-by-point telemetry.
+
+## Goals
+
+- Let users inspect activity telemetry by either elapsed time or cumulative distance.
+- Keep one shared x-axis mode across all eligible Individual page telemetry charts.
+- Preserve existing zoom, smoothing, lap marker, tooltip, and unit behaviour as much as possible.
+- Avoid backend or parser changes unless frontend data proves insufficient.
+
+## Non-Goals
+
+- Do not change overview charts, comparison charts, maps, lap tables, or exports.
+- Do not convert distribution charts to distance mode.
+- Do not include the effort heatmap in this feature.
+- Do not change the stored activity or record schema.
+
+## Eligible Charts
+
+The following Individual page charts should support the Time/Distance x-axis toggle:
+
+- Heart Rate
+- Pace
+- Speed Trend
+- Cadence
+- Cadence and Power
+- Elevation
+
+The following Individual page charts are not time-based telemetry line charts and should not change:
+
+- Heart Rate Zone Time pie chart
+- Heart Rate histogram
+- Power vs Heart Rate scatter chart
+- Effort heatmap
+
+## Existing Data
+
+`RecordPoint` already includes `distance_m`, so the frontend has the core data needed for distance-axis charting.
+
+Downsampled records currently return `distance_m` using `MAX(distance_m)` for each time bucket. That is acceptable for a cumulative distance x-axis because it keeps each bucket at the furthest known distance in that interval.
+
+The parser also derives cumulative distance from GPS points when an activity file has no native distance field. Activities without usable distance data can still exist, so the frontend needs a fallback state.
+
+## User Experience
+
+Add a compact segmented control in the Individual page detail header near the existing Smooth graphs and Reset Zoom controls:
+
+- Time
+- Distance
+
+Default mode is Time.
+
+The selected x-axis mode is local UI state. It should not persist across sessions in the initial implementation. This matches the existing Individual page chart controls, such as zoom and graph smoothing, which are held in `Dashboard` state rather than stored in global settings.
+
+When Distance is selected:
+
+- Eligible chart x-axes display cumulative distance in the user-selected distance unit.
+- Tooltips still show elapsed time and absolute clock time for context.
+- Tooltips should also show distance where useful.
+- Lap markers move to their corresponding cumulative distance positions.
+
+When an activity has no usable distance data:
+
+- Reset the mode to Time when switching to that activity.
+- Disable Distance for that activity.
+- Prefer disabling Distance with a concise tooltip over silently accepting a mode that cannot be rendered.
+
+## Axis Model
+
+Introduce a frontend type such as:
+
+```ts
+type TelemetryXAxisMode = "time" | "distance";
+```
+
+For each record, build a common chart point context:
+
+```ts
+type TelemetryPoint = {
+  x: number;
+  relMs: number;
+  timestampMs: number;
+  distanceMeters: number | null;
+};
+```
+
+For Time mode:
+
+- `x = relMs`
+- each axis tick uses elapsed time formatting
+
+For Distance mode:
+
+- `x = convertDistanceMeters(distanceMeters, distanceUnit)`
+- each axis tick uses distance formatting with the active distance unit, such as `1.25 km` or `0.75 mi`
+
+Series should keep additional values in the row so tooltip formatters can show both time and distance regardless of current x-axis mode.
+
+## Lap Markers
+
+Current lap markers are timestamp based. Distance mode needs lap marker x-values derived from record distance.
+
+Recommended approach:
+
+1. Parse each lap timestamp.
+2. Find the nearest surrounding records by timestamp.
+3. Interpolate distance between the surrounding records when both have finite `distance_m`.
+4. Fall back to the nearest record distance if interpolation is not possible.
+5. Omit the marker if no finite distance is available.
+
+Time mode can keep the current elapsed-time marker calculation.
+
+## Zoom Behaviour
+
+Current chart zoom state is stored as ECharts percentage ranges (`start` and `end`), not raw x-axis values. That can remain shared across Time and Distance modes.
+
+Changing x-axis mode should not require resetting zoom. The same visible percentage range can be applied to the newly selected axis.
+
+The existing Reset Zoom button should continue to clear the shared zoom state.
+
+## Smoothing
+
+Smoothing currently uses a dynamic window based on record count, elapsed duration, and visible zoom percentage.
+
+For the initial implementation, keep the existing smoothing calculation. Distance mode changes the x-coordinate but not the sample order, so rolling averages remain valid.
+
+A future refinement could calculate the smoothing window from visible distance instead of visible duration, but that is not required for this feature.
+
+## Implementation Plan
+
+1. Add `TelemetryXAxisMode` state to `Dashboard`.
+2. Add Time/Distance segmented control to the Individual page detail header.
+3. Pass `xAxisMode` into `ActivityChart` and `ActivityInsights`.
+4. Add shared x-axis formatting helpers for time and distance labels.
+5. Refactor `ActivityChart` series data so Heart Rate and Pace use the selected x-axis value.
+6. Refactor `ActivityInsights` time-based line chart data for Speed Trend, Cadence, Power, and Elevation.
+7. Update tooltip headers to include both time and distance context.
+8. Update lap marker creation to support both time and distance modes.
+9. Reset the x-axis mode to Time when the selected activity has no finite distance samples.
+10. Leave the effort heatmap unchanged and document that it is excluded because it is minute-binned.
+11. Add translation keys for the new control labels and tooltip text.
+
+## Validation
+
+Manual validation should cover:
+
+- Time mode remains visually unchanged from current behaviour.
+- Distance mode works on an activity with complete distance samples.
+- Distance mode is disabled or unavailable for an activity with no finite distance samples.
+- Switching to an activity with no finite distance samples resets the mode to Time.
+- Lap markers appear in correct positions in both modes.
+- Shared zoom still affects all eligible time-based charts.
+- Reset Zoom works in both modes.
+- Smooth graphs still applies in both modes.
+- The effort heatmap remains time-binned and is unaffected by the toggle.
+

--- a/docs/features/chart-distance-axis.md
+++ b/docs/features/chart-distance-axis.md
@@ -158,4 +158,3 @@ Manual validation should cover:
 - Reset Zoom works in both modes.
 - Smooth graphs still applies in both modes.
 - The effort heatmap remains time-binned and is unaffected by the toggle.
-

--- a/src/components/ActivityChart.tsx
+++ b/src/components/ActivityChart.tsx
@@ -3,13 +3,21 @@ import type { RecordPoint } from "../types";
 import { enableChartWheelPageScroll } from "../lib/chartScroll";
 import { buildHeartRateZones } from "../lib/hrZones";
 import { applyRollingAverageSeries, getDynamicSmoothingWindow } from "../lib/chartSmoothing";
-import { convertDistanceMeters, convertPaceMinPerKm, distanceLabel, paceLabel, type DistanceUnit } from "../lib/units";
+import { convertPaceMinPerKm, paceLabel, type DistanceUnit } from "../lib/units";
+import {
+  buildLapMarkers,
+  buildTelemetryPoints,
+  formatTelemetryTooltipHeader,
+  formatTelemetryXAxisTick,
+  type TelemetryXAxisMode,
+} from "../lib/telemetryAxis";
 import { useTranslation } from "../lib/i18n";
 
 type Props = {
   records: RecordPoint[];
   theme: "light" | "dark";
   distanceUnit: DistanceUnit;
+  xAxisMode?: TelemetryXAxisMode;
   heartRateZoneBoundsBpm?: number[];
   zoomRange?: { start: number; end: number } | null;
   onZoomChange?: (range: { start: number; end: number }) => void;
@@ -17,10 +25,17 @@ type Props = {
   smoothGraphs?: boolean;
 };
 
+type SeriesRow = [number, number | null, number, number, number | null];
+
+function isSeriesRow(row: [number | null, number | null, number, number, number | null]): row is SeriesRow {
+  return typeof row[0] === "number" && Number.isFinite(row[0]);
+}
+
 export function ActivityChart({
   records,
   theme,
   distanceUnit,
+  xAxisMode = "time",
   heartRateZoneBoundsBpm,
   zoomRange,
   onZoomChange,
@@ -31,59 +46,35 @@ export function ActivityChart({
   const totalDurationMs = Math.max(0, (records[records.length - 1]?.timestamp_ms ?? t0) - t0);
   const smoothWindow = smoothGraphs ? getDynamicSmoothingWindow(records.length, totalDurationMs, zoomRange) : 1;
   const { t } = useTranslation();
-  
-  // Format MM:SS or HH:MM:SS
-  const formatRelTime = (ms: number) => {
-    const totalSec = Math.floor(Math.max(0, ms) / 1000);
-    const h = Math.floor(totalSec / 3600);
-    const m = Math.floor((totalSec % 3600) / 60);
-    const s = totalSec % 60;
-    if (h > 0) {
-      return `${h}:${m.toString().padStart(2, "0")}:${s.toString().padStart(2, "0")}`;
-    }
-    return `${m}:${s.toString().padStart(2, "0")}`;
-  };
 
-  const formatAbsTime = (relMs: number) => {
-    const absolute = new Date(t0 + Math.max(0, relMs));
-    const hh = String(absolute.getHours()).padStart(2, "0");
-    const mm = String(absolute.getMinutes()).padStart(2, "0");
-    const ss = String(absolute.getSeconds()).padStart(2, "0");
-    return `${hh}:${mm}:${ss}`;
-  };
-
-  const formatTooltipHeader = (relMs: number) =>
-    `<div style="display:flex;align-items:center;gap:6px;"><strong>${formatRelTime(relMs)}</strong><span style="display:inline-flex;align-items:center;border-radius:999px;padding:1px 6px;font-size:11px;background:rgba(148,163,184,0.22);">${formatAbsTime(relMs)}</span></div>`;
+  const telemetryPoints = buildTelemetryPoints(records, t0, xAxisMode, distanceUnit);
+  const formatTooltipHeader = (relMs: number, distanceMeters: number | null) =>
+    formatTelemetryTooltipHeader(xAxisMode, t0, relMs, distanceMeters, distanceUnit);
 
   const hrZones = buildHeartRateZones(heartRateZoneBoundsBpm);
-  const hrSeriesData = records.map((r) => [r.timestamp_ms - t0, r.heart_rate ?? null, r.timestamp_ms, typeof r.distance_m === "number" ? r.distance_m / 1000 : null]);
-  const paceSeriesData = records.map((r, i) => {
-    const relMs = r.timestamp_ms - t0;
-    const prev = i > 0 ? records[i - 1] : undefined;
-    const dtS = prev ? (r.timestamp_ms - prev.timestamp_ms) / 1000 : 0;
-    const derivedSpeed =
-      (!r.speed_m_s && prev && typeof r.distance_m === "number" && typeof prev.distance_m === "number" && dtS > 0)
-        ? Math.max(0, (r.distance_m - prev.distance_m) / dtS)
-        : undefined;
-    const speedMs = r.speed_m_s ?? derivedSpeed;
-    const paceMinPerKm = speedMs && speedMs > 0 ? 1000 / (speedMs * 60) : null;
-    const paceMinPerUnit = paceMinPerKm == null ? null : convertPaceMinPerKm(paceMinPerKm, distanceUnit);
-    return [relMs, paceMinPerUnit, r.timestamp_ms];
-  });
+  const hrSeriesData = telemetryPoints
+    .map((point, i) => [point.x, records[i].heart_rate ?? null, point.relMs, point.timestampMs, point.distanceMeters] as [number | null, number | null, number, number, number | null])
+    .filter(isSeriesRow);
+  const paceSeriesData = telemetryPoints
+    .map((point, i) => {
+      const record = records[i];
+      const prev = i > 0 ? records[i - 1] : undefined;
+      const dtS = prev ? (record.timestamp_ms - prev.timestamp_ms) / 1000 : 0;
+      const derivedSpeed =
+        (!record.speed_m_s && prev && typeof record.distance_m === "number" && typeof prev.distance_m === "number" && dtS > 0)
+          ? Math.max(0, (record.distance_m - prev.distance_m) / dtS)
+          : undefined;
+      const speedMs = record.speed_m_s ?? derivedSpeed;
+      const paceMinPerKm = speedMs && speedMs > 0 ? 1000 / (speedMs * 60) : null;
+      const paceMinPerUnit = paceMinPerKm == null ? null : convertPaceMinPerKm(paceMinPerKm, distanceUnit);
+      return [point.x, paceMinPerUnit, point.relMs, point.timestampMs, point.distanceMeters] as [number | null, number | null, number, number, number | null];
+    })
+    .filter(isSeriesRow);
 
   const hrSeriesSmoothed = smoothGraphs ? applyRollingAverageSeries(hrSeriesData, 1, smoothWindow) : hrSeriesData;
   const paceSeriesSmoothed = smoothGraphs ? applyRollingAverageSeries(paceSeriesData, 1, smoothWindow) : paceSeriesData;
 
-  const lapMarkers = lapTimestampsUtc
-    .slice(1)
-    .map((ts, idx) => {
-      const parsed = Date.parse(ts);
-      if (!Number.isFinite(parsed)) return null;
-      const relMs = parsed - t0;
-      if (relMs < 0) return null;
-      return { xAxis: relMs, name: `Lap ${idx + 1}` };
-    })
-    .filter((m): m is { xAxis: number; name: string } => m !== null);
+  const lapMarkers = buildLapMarkers(records, lapTimestampsUtc, t0, xAxisMode, distanceUnit);
 
   const isDark = theme === "dark";
   const axisColor = isDark ? "#8899b8" : "#64748b";
@@ -91,6 +82,17 @@ export function ActivityChart({
   const tooltipBg = isDark ? "rgba(14, 22, 45, 0.95)" : "rgba(255, 255, 255, 0.95)";
   const tooltipBorder = isDark ? "rgba(100, 140, 220, 0.2)" : "rgba(0, 0, 0, 0.08)";
   const tooltipText = isDark ? "#e2e8f4" : "#0f172a";
+
+  const sharedXAxis = {
+    type: "value",
+    axisLabel: {
+      color: axisColor,
+      fontSize: 11,
+      formatter: (val: number) => formatTelemetryXAxisTick(val, xAxisMode, distanceUnit),
+    },
+    axisLine: { lineStyle: { color: gridLine } },
+    splitLine: { show: false },
+  };
 
   const hrOption = {
     tooltip: {
@@ -100,17 +102,13 @@ export function ActivityChart({
       textStyle: { color: tooltipText, fontSize: 12 },
       formatter: (params: any) => {
         const p = params[0];
-        const relTime = Number(p.value[0] ?? 0);
-        let html = formatTooltipHeader(relTime);
+        const relTime = Number(p.value[2] ?? 0);
+        const distanceMeters = p?.value?.[4] as number | null | undefined;
+        let html = formatTooltipHeader(relTime, distanceMeters ?? null);
         for (const s of params) {
           if (s.value[1] !== null && s.value[1] !== undefined) {
             html += `<div>${s.marker} ${s.seriesName}: <strong>${s.value[1]}</strong></div>`;
           }
-        }
-        const distanceKm = p?.value?.[3] as number | null | undefined;
-        if (distanceKm !== null && distanceKm !== undefined) {
-          const distanceInUnit = convertDistanceMeters(Number(distanceKm) * 1000, distanceUnit);
-          html += `<div style="margin-top:2px;">${t("chart.distance")}: <strong>${distanceInUnit.toFixed(2)} ${distanceLabel(distanceUnit)}</strong></div>`;
         }
         return html;
       }
@@ -135,16 +133,7 @@ export function ActivityChart({
       }),
     },
     grid: { left: 48, right: 16, top: 36, bottom: 38 },
-    xAxis: {
-      type: "value",
-      axisLabel: {
-        color: axisColor,
-        fontSize: 11,
-        formatter: (val: number) => formatRelTime(val)
-      },
-      axisLine: { lineStyle: { color: gridLine } },
-      splitLine: { show: false },
-    },
+    xAxis: sharedXAxis,
     yAxis: {
       type: "value",
       name: "bpm",
@@ -191,8 +180,9 @@ export function ActivityChart({
       textStyle: { color: tooltipText, fontSize: 12 },
       formatter: (params: any) => {
         const p = params[0];
-        const relTime = Number(p.value[0] ?? 0);
-        let html = formatTooltipHeader(relTime);
+        const relTime = Number(p.value[2] ?? 0);
+        const distanceMeters = p?.value?.[4] as number | null | undefined;
+        let html = formatTooltipHeader(relTime, distanceMeters ?? null);
         for (const s of params) {
           if (s.value[1] !== null && s.value[1] !== undefined) {
             const pace = Number(s.value[1]);
@@ -210,16 +200,7 @@ export function ActivityChart({
       top: 0,
     },
     grid: { left: 48, right: 16, top: 36, bottom: 38 },
-    xAxis: {
-      type: "value",
-      axisLabel: {
-        color: axisColor,
-        fontSize: 11,
-        formatter: (val: number) => formatRelTime(val)
-      },
-      axisLine: { lineStyle: { color: gridLine } },
-      splitLine: { show: false },
-    },
+    xAxis: sharedXAxis,
     yAxis: {
       type: "value",
       name: paceLabel(distanceUnit),

--- a/src/components/ActivityInsights.tsx
+++ b/src/components/ActivityInsights.tsx
@@ -10,12 +10,21 @@ import {
   speedLabel,
   type DistanceUnit,
 } from "../lib/units";
+import {
+  buildLapMarkers,
+  buildTelemetryPoints,
+  formatRelTime,
+  formatTelemetryTooltipHeader,
+  formatTelemetryXAxisTick,
+  type TelemetryXAxisMode,
+} from "../lib/telemetryAxis";
 import { useTranslation } from "../lib/i18n";
 
 type Props = {
   records: RecordPoint[];
   theme: "light" | "dark";
   distanceUnit: DistanceUnit;
+  xAxisMode?: TelemetryXAxisMode;
   heartRateZoneBoundsBpm?: number[];
   zoomRange?: { start: number; end: number } | null;
   onZoomChange?: (range: { start: number; end: number }) => void;
@@ -23,42 +32,30 @@ type Props = {
   smoothGraphs?: boolean;
 };
 
+type SeriesRow = [number, number | null, number, number, number | null];
+
+function isSeriesRow(row: [number | null, number | null, number, number, number | null]): row is SeriesRow {
+  return typeof row[0] === "number" && Number.isFinite(row[0]);
+}
+
 function safeAvg(values: Array<number | null | undefined>): number | null {
   const nums = values.filter((v): v is number => typeof v === "number" && Number.isFinite(v));
   if (!nums.length) return null;
   return nums.reduce((sum, n) => sum + n, 0) / nums.length;
 }
 
-function formatRelTime(ms: number): string {
-  const totalSec = Math.floor(Math.max(0, ms) / 1000);
-  const h = Math.floor(totalSec / 3600);
-  const m = Math.floor((totalSec % 3600) / 60);
-  const s = totalSec % 60;
-  if (h > 0) {
-    return `${h}:${m.toString().padStart(2, "0")}:${s.toString().padStart(2, "0")}`;
-  }
-  return `${m}:${s.toString().padStart(2, "0")}`;
-}
-
-function formatAbsTime(baseTimestampMs: number, relMs: number): string {
-  const absolute = new Date(baseTimestampMs + Math.max(0, relMs));
-  const hh = String(absolute.getHours()).padStart(2, "0");
-  const mm = String(absolute.getMinutes()).padStart(2, "0");
-  const ss = String(absolute.getSeconds()).padStart(2, "0");
-  return `${hh}:${mm}:${ss}`;
-}
-
 export function ActivityInsights({
   records,
   theme,
   distanceUnit,
+  xAxisMode = "time",
   heartRateZoneBoundsBpm,
   zoomRange,
   onZoomChange,
   lapTimestampsUtc = [],
   smoothGraphs = true,
 }: Props) {
-    const hrZones = buildHeartRateZones(heartRateZoneBoundsBpm);
+  const hrZones = buildHeartRateZones(heartRateZoneBoundsBpm);
   const isDark = theme === "dark";
   const { t: tr } = useTranslation();
   const axisColor = isDark ? "#8899b8" : "#64748b";
@@ -72,8 +69,6 @@ export function ActivityInsights({
     borderColor: tooltipBorder,
     textStyle: { color: tooltipText, fontSize: 12 },
   };
-  const formatTooltipHeader = (relMs: number) =>
-    `<div style="display:flex;align-items:center;gap:6px;"><strong>${formatRelTime(relMs)}</strong><span style="display:inline-flex;align-items:center;border-radius:999px;padding:1px 6px;font-size:11px;background:rgba(148,163,184,0.22);">${formatAbsTime(t0, relMs)}</span></div>`;
 
   if (!records.length) {
     return (
@@ -87,6 +82,10 @@ export function ActivityInsights({
   const t0 = records[0]?.timestamp_ms ?? 0;
   const totalDurationMs = Math.max(0, (records[records.length - 1]?.timestamp_ms ?? t0) - t0);
   const smoothWindow = smoothGraphs ? getDynamicSmoothingWindow(records.length, totalDurationMs, zoomRange) : 1;
+  const telemetryPoints = buildTelemetryPoints(records, t0, xAxisMode, distanceUnit);
+  const formatTooltipHeader = (relMs: number, distanceMeters: number | null, mode: TelemetryXAxisMode = xAxisMode) =>
+    formatTelemetryTooltipHeader(mode, t0, relMs, distanceMeters, distanceUnit);
+
   const timeline = records.map((r, i) => {
     const prev = i > 0 ? records[i - 1] : undefined;
     const dt = prev ? (r.timestamp_ms - prev.timestamp_ms) / 1000 : 0;
@@ -97,8 +96,11 @@ export function ActivityInsights({
     const speedMs = r.speed_m_s ?? derivedSpeed;
     const speedInUnit = typeof speedMs === "number" ? convertSpeedMps(speedMs, distanceUnit) : null;
     const paceMinPerUnit = speedInUnit && speedInUnit > 0 ? 60 / speedInUnit : null;
+    const point = telemetryPoints[i];
     return {
-      relMs: r.timestamp_ms - t0,
+      x: point.x,
+      relMs: point.relMs,
+      distanceMeters: point.distanceMeters,
       speedInUnit,
       altitudeInUnit: typeof r.altitude_m === "number" ? convertElevationMeters(r.altitude_m, distanceUnit) : null,
       paceMinPerUnit,
@@ -110,10 +112,10 @@ export function ActivityInsights({
     };
   });
 
-  const speedLineData = timeline.map((d) => [d.relMs, d.speedInUnit]);
-  const elevationLineData = timeline.map((d) => [d.relMs, d.altitudeInUnit]);
-  const cadenceLineData = timeline.map((d) => [d.relMs, d.cadence]);
-  const powerLineData = timeline.map((d) => [d.relMs, d.power]);
+  const speedLineData = timeline.map((d) => [d.x, d.speedInUnit, d.relMs, d.timestampMs, d.distanceMeters] as [number | null, number | null, number, number, number | null]).filter(isSeriesRow);
+  const elevationLineData = timeline.map((d) => [d.x, d.altitudeInUnit, d.relMs, d.timestampMs, d.distanceMeters] as [number | null, number | null, number, number, number | null]).filter(isSeriesRow);
+  const cadenceLineData = timeline.map((d) => [d.x, d.cadence, d.relMs, d.timestampMs, d.distanceMeters] as [number | null, number | null, number, number, number | null]).filter(isSeriesRow);
+  const powerLineData = timeline.map((d) => [d.x, d.power, d.relMs, d.timestampMs, d.distanceMeters] as [number | null, number | null, number, number, number | null]).filter(isSeriesRow);
 
   const speedLineDataSmoothed = smoothGraphs ? applyRollingAverageSeries(speedLineData, 1, smoothWindow) : speedLineData;
   const elevationLineDataSmoothed = smoothGraphs ? applyRollingAverageSeries(elevationLineData, 1, smoothWindow) : elevationLineData;
@@ -123,16 +125,7 @@ export function ActivityInsights({
   const hasPowerData = records.some((r) => typeof r.power === "number" && r.power > 0);
   const hasHeartRateData = records.some((r) => typeof r.heart_rate === "number" && r.heart_rate > 0);
 
-  const lapMarkers = lapTimestampsUtc
-    .slice(1)
-    .map((ts, idx) => {
-      const parsed = Date.parse(ts);
-      if (!Number.isFinite(parsed)) return null;
-      const relMs = parsed - t0;
-      if (relMs < 0) return null;
-      return { xAxis: relMs, name: `Lap ${idx + 1}` };
-    })
-    .filter((m): m is { xAxis: number; name: string } => m !== null);
+  const lapMarkers = buildLapMarkers(records, lapTimestampsUtc, t0, xAxisMode, distanceUnit);
 
   const hrValues = records
     .map((r) => r.heart_rate)
@@ -148,14 +141,22 @@ export function ActivityInsights({
     }
   }
 
+  const sharedXAxis = {
+    type: "value",
+    axisLabel: { color: axisColor, fontSize: 11, formatter: (val: number) => formatTelemetryXAxisTick(val, xAxisMode, distanceUnit) },
+    axisLine: { lineStyle: { color: gridLine } },
+    splitLine: { show: false },
+  };
+
   const timelineOption = {
     tooltip: {
       trigger: "axis",
       ...tooltipStyle,
       formatter: (params: any[]) => {
         const p = params?.[0];
-        const rel = Number(p?.value?.[0] ?? 0);
-        let html = formatTooltipHeader(rel);
+        const rel = Number(p?.value?.[2] ?? 0);
+        const distanceMeters = (p?.value?.[4] ?? null) as number | null;
+        let html = formatTooltipHeader(rel, distanceMeters);
         for (const row of params) {
           if (row.value?.[1] !== null && row.value?.[1] !== undefined) {
             html += `<div>${row.marker} ${row.seriesName}: <strong>${Number(row.value[1]).toFixed(2)}</strong></div>`;
@@ -166,12 +167,7 @@ export function ActivityInsights({
     },
     legend: { textStyle: { color: axisColor, fontSize: 12 }, top: 0 },
     grid: { left: 50, right: 16, top: 42, bottom: 46 },
-    xAxis: {
-      type: "value",
-      axisLabel: { color: axisColor, fontSize: 11, formatter: (val: number) => formatRelTime(val) },
-      axisLine: { lineStyle: { color: gridLine } },
-      splitLine: { show: false },
-    },
+    xAxis: sharedXAxis,
     yAxis: {
       type: "value", name: speedLabel(distanceUnit),
       nameTextStyle: { color: axisColor, fontSize: 11 },
@@ -211,19 +207,15 @@ export function ActivityInsights({
       ...tooltipStyle,
       formatter: (params: any[]) => {
         const p = params?.[0];
-        const rel = Number(p?.value?.[0] ?? 0);
+        const rel = Number(p?.value?.[2] ?? 0);
+        const distanceMeters = (p?.value?.[4] ?? null) as number | null;
         const val = p?.value?.[1];
-        return `${formatTooltipHeader(rel)}<div>${p?.marker ?? ""} Elevation: <strong>${val == null ? "--" : Number(val).toFixed(2)} ${elevationLabel(distanceUnit)}</strong></div>`;
+        return `${formatTooltipHeader(rel, distanceMeters)}<div>${p?.marker ?? ""} ${tr("insights.elevation")}: <strong>${val == null ? "--" : Number(val).toFixed(2)} ${elevationLabel(distanceUnit)}</strong></div>`;
       }
     },
     legend: { textStyle: { color: axisColor, fontSize: 12 }, top: 0 },
     grid: { left: 50, right: 16, top: 42, bottom: 46 },
-    xAxis: {
-      type: "value",
-      axisLabel: { color: axisColor, fontSize: 11, formatter: (val: number) => formatRelTime(val) },
-      axisLine: { lineStyle: { color: gridLine } },
-      splitLine: { show: false },
-    },
+    xAxis: sharedXAxis,
     yAxis: {
       type: "value", name: elevationLabel(distanceUnit),
       nameTextStyle: { color: axisColor, fontSize: 11 },
@@ -289,11 +281,12 @@ export function ActivityInsights({
       ...tooltipStyle,
       formatter: (params: any[]) => {
         const p = params?.[0];
-        const rel = Number(p?.value?.[0] ?? 0);
-        let html = formatTooltipHeader(rel);
+        const rel = Number(p?.value?.[2] ?? 0);
+        const distanceMeters = (p?.value?.[4] ?? null) as number | null;
+        let html = formatTooltipHeader(rel, distanceMeters);
         for (const row of params) {
           if (row.value?.[1] !== null && row.value?.[1] !== undefined) {
-            const unit = row.seriesName === "Cadence" ? " rpm" : " W";
+            const unit = row.seriesName === tr("insights.cadence") ? " rpm" : " W";
             html += `<div>${row.marker} ${row.seriesName}: <strong>${Number(row.value[1]).toFixed(2)}${unit}</strong></div>`;
           }
         }
@@ -302,12 +295,7 @@ export function ActivityInsights({
     },
     legend: { textStyle: { color: axisColor, fontSize: 12 }, top: 0 },
     grid: { left: 44, right: hasPowerData ? 44 : 16, top: 44, bottom: 44 },
-    xAxis: {
-      type: "value",
-      axisLabel: { color: axisColor, fontSize: 11, formatter: (val: number) => formatRelTime(val) },
-      axisLine: { lineStyle: { color: gridLine } },
-      splitLine: { show: false },
-    },
+    xAxis: sharedXAxis,
     yAxis: [
       {
         type: "value", name: "rpm",
@@ -541,7 +529,7 @@ export function ActivityInsights({
         const startMs = minuteIdx * 60000;
         const endMs = (minuteIdx + 1) * 60000;
         const valueText = value === null ? "--" : `${value.toFixed(2)} ${unit}`;
-        return `<div><strong>${label}</strong></div>${formatTooltipHeader(startMs)}<div>${formatRelTime(startMs)} - ${formatRelTime(endMs)}: <strong>${valueText}</strong></div>`;
+        return `<div><strong>${label}</strong></div>${formatTooltipHeader(startMs, null, "time")}<div>${formatRelTime(startMs)} - ${formatRelTime(endMs)}: <strong>${valueText}</strong></div>`;
       },
     },
     grid: rowTop.map((top) => ({ left: 58, right: 14, top, height: rowHeight })),

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -30,6 +30,7 @@ import {
   speedLabel,
 } from "../lib/units";
 import { useTranslation } from "../lib/i18n";
+import { hasUsableDistanceAxis, type TelemetryXAxisMode } from "../lib/telemetryAxis";
 
 type Props = { onLogout: () => Promise<void> };
 
@@ -318,6 +319,7 @@ export function Dashboard({ onLogout }: Props) {
     x: number; y: number; activityId: number; activityName: string;
   } | null>(null);
   const [telemetryZoom, setTelemetryZoom] = useState<{ start: number; end: number } | null>(null);
+  const [telemetryXAxisMode, setTelemetryXAxisMode] = useState<TelemetryXAxisMode>("time");
   const [smoothGraphs, setSmoothGraphs] = useState(true);
   const [appVersion, setAppVersion] = useState("unknown");
   const [versionBadgeStatus, setVersionBadgeStatus] = useState<VersionBadgeStatus>({ state: "hidden", latestVersion: null });
@@ -481,6 +483,7 @@ export function Dashboard({ onLogout }: Props) {
   const filteredSports = Array.from(new Set(filtered.map((a) => a.sport).filter(Boolean)));
   const filteredDevices = Array.from(new Set(filtered.map((a) => a.device).filter(Boolean)));
   const selectedRecords = tab === "overview" ? overviewRecords : records;
+  const hasTelemetryDistanceAxis = useMemo(() => hasUsableDistanceAxis(records), [records]);
   const distanceDivisorValue = distanceDivisor(distanceUnit);
   const distanceSuffix = distanceLabel(distanceUnit);
   const filteredTotalDistanceM = filtered.reduce((sum, a) => sum + a.distance_m, 0);
@@ -1022,6 +1025,12 @@ export function Dashboard({ onLogout }: Props) {
       .filter((ts) => !!ts),
     [selectedMetadata]
   );
+
+  useEffect(() => {
+    if (selectedActivity && records.length > 0 && !hasTelemetryDistanceAxis && telemetryXAxisMode === "distance") {
+      setTelemetryXAxisMode("time");
+    }
+  }, [selectedActivity, records.length, hasTelemetryDistanceAxis, telemetryXAxisMode]);
   const deviceBadgeSerial = typeof selectedMetadata?.file_id?.serial_number === "number"
     ? String(selectedMetadata.file_id.serial_number)
     : "";
@@ -1564,6 +1573,24 @@ export function Dashboard({ onLogout }: Props) {
                     <span className="badge">{formatDate(selectedActivity.start_ts_utc)}</span>
                     {selectedActivity.sport && <span className="badge sport">{selectedActivity.sport}</span>}
                     {deviceBadgeSerial && <span className="badge device">SN {deviceBadgeSerial}</span>}
+                    <div className="detail-axis-toggle" aria-label={t("detail.chartXAxis")}>
+                      <button
+                        type="button"
+                        className={telemetryXAxisMode === "time" ? "active" : ""}
+                        onClick={() => setTelemetryXAxisMode("time")}
+                      >
+                        {t("detail.time")}
+                      </button>
+                      <button
+                        type="button"
+                        className={telemetryXAxisMode === "distance" ? "active" : ""}
+                        onClick={() => hasTelemetryDistanceAxis && setTelemetryXAxisMode("distance")}
+                        disabled={!hasTelemetryDistanceAxis}
+                        title={!hasTelemetryDistanceAxis ? t("detail.distanceAxisUnavailable") : undefined}
+                      >
+                        {t("detail.distance")}
+                      </button>
+                    </div>
                     <label className="detail-toggle-badge" title={t("detail.smoothGraphsTooltip")}>
                       <input
                         type="checkbox"
@@ -1601,10 +1628,10 @@ export function Dashboard({ onLogout }: Props) {
                 </div>
               </div>
               <div className="detail-grid">
-                <div className="panel"><h3>{t("detail.heartRateAndPace")}</h3><ActivityChart records={selectedRecords} theme={theme} distanceUnit={distanceUnit} heartRateZoneBoundsBpm={selectedMetadata?.heart_rate_zone_bounds_bpm} zoomRange={telemetryZoom} onZoomChange={setTelemetryZoom} lapTimestampsUtc={lapTimestampsUtc} smoothGraphs={smoothGraphs} /></div>
+                <div className="panel"><h3>{t("detail.heartRateAndPace")}</h3><ActivityChart records={selectedRecords} theme={theme} distanceUnit={distanceUnit} xAxisMode={telemetryXAxisMode} heartRateZoneBoundsBpm={selectedMetadata?.heart_rate_zone_bounds_bpm} zoomRange={telemetryZoom} onZoomChange={setTelemetryZoom} lapTimestampsUtc={lapTimestampsUtc} smoothGraphs={smoothGraphs} /></div>
                 <ActivityMap records={selectedRecords} mapStyle={mapStyle} setMapStyle={setMapStyle} lapTimestampsUtc={lapTimestampsUtc} />
               </div>
-              <ActivityInsights records={selectedRecords} theme={theme} distanceUnit={distanceUnit} heartRateZoneBoundsBpm={selectedMetadata?.heart_rate_zone_bounds_bpm} zoomRange={telemetryZoom} onZoomChange={setTelemetryZoom} lapTimestampsUtc={lapTimestampsUtc} smoothGraphs={smoothGraphs} />
+              <ActivityInsights records={selectedRecords} theme={theme} distanceUnit={distanceUnit} xAxisMode={telemetryXAxisMode} heartRateZoneBoundsBpm={selectedMetadata?.heart_rate_zone_bounds_bpm} zoomRange={telemetryZoom} onZoomChange={setTelemetryZoom} lapTimestampsUtc={lapTimestampsUtc} smoothGraphs={smoothGraphs} />
               {lapRows.length > 0 && (
                 <div className="panel laps-table-panel">
                   <h3>{t("detail.laps")}</h3>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -111,6 +111,8 @@
   "detail.calories": "Calories",
   "detail.laps": "Laps",
   "detail.smoothGraphs": "Smooth graphs",
+  "detail.chartXAxis": "Chart x-axis",
+  "detail.distanceAxisUnavailable": "Distance axis unavailable for this activity",
   "detail.resetZoom": "Reset Zoom",
   "detail.heartRateAndPace": "Heart Rate and Pace",
   "detail.selectActivity": "Select an activity from the sidebar to inspect individual telemetry.",

--- a/src/lib/telemetryAxis.ts
+++ b/src/lib/telemetryAxis.ts
@@ -1,0 +1,158 @@
+import type { RecordPoint } from "../types";
+import { convertDistanceMeters, distanceLabel, type DistanceUnit } from "./units";
+
+export type TelemetryXAxisMode = "time" | "distance";
+
+export type TelemetryPoint = {
+  x: number | null;
+  relMs: number;
+  timestampMs: number;
+  distanceMeters: number | null;
+};
+
+type LapMarker = { xAxis: number; name: string };
+
+function finiteDistanceMeters(record: RecordPoint): number | null {
+  return typeof record.distance_m === "number" && Number.isFinite(record.distance_m)
+    ? Math.max(0, record.distance_m)
+    : null;
+}
+
+export function hasUsableDistanceAxis(records: RecordPoint[]): boolean {
+  return records.some((record) => {
+    const distanceMeters = finiteDistanceMeters(record);
+    return distanceMeters !== null && distanceMeters > 0;
+  });
+}
+
+export function buildTelemetryPoints(
+  records: RecordPoint[],
+  startTimestampMs: number,
+  mode: TelemetryXAxisMode,
+  distanceUnit: DistanceUnit,
+): TelemetryPoint[] {
+  return records.map((record) => {
+    const distanceMeters = finiteDistanceMeters(record);
+    return {
+      x: mode === "distance"
+        ? (distanceMeters === null ? null : convertDistanceMeters(distanceMeters, distanceUnit))
+        : record.timestamp_ms - startTimestampMs,
+      relMs: record.timestamp_ms - startTimestampMs,
+      timestampMs: record.timestamp_ms,
+      distanceMeters,
+    };
+  });
+}
+
+export function formatRelTime(ms: number): string {
+  const totalSec = Math.floor(Math.max(0, ms) / 1000);
+  const h = Math.floor(totalSec / 3600);
+  const m = Math.floor((totalSec % 3600) / 60);
+  const s = totalSec % 60;
+  if (h > 0) {
+    return `${h}:${m.toString().padStart(2, "0")}:${s.toString().padStart(2, "0")}`;
+  }
+  return `${m}:${s.toString().padStart(2, "0")}`;
+}
+
+export function formatAbsTime(baseTimestampMs: number, relMs: number): string {
+  const absolute = new Date(baseTimestampMs + Math.max(0, relMs));
+  const hh = String(absolute.getHours()).padStart(2, "0");
+  const mm = String(absolute.getMinutes()).padStart(2, "0");
+  const ss = String(absolute.getSeconds()).padStart(2, "0");
+  return `${hh}:${mm}:${ss}`;
+}
+
+export function formatDistanceAxisTick(value: number, unit: DistanceUnit): string {
+  const abs = Math.abs(value);
+  const digits = abs >= 100 ? 0 : abs >= 10 ? 1 : 2;
+  return `${value.toFixed(digits)} ${distanceLabel(unit)}`;
+}
+
+export function formatTelemetryXAxisTick(
+  value: number,
+  mode: TelemetryXAxisMode,
+  distanceUnit: DistanceUnit,
+): string {
+  return mode === "distance" ? formatDistanceAxisTick(value, distanceUnit) : formatRelTime(value);
+}
+
+export function formatTelemetryTooltipHeader(
+  mode: TelemetryXAxisMode,
+  baseTimestampMs: number,
+  relMs: number,
+  distanceMeters: number | null,
+  distanceUnit: DistanceUnit,
+): string {
+  const distanceValue = distanceMeters === null ? null : convertDistanceMeters(distanceMeters, distanceUnit);
+  const primary = mode === "distance" && distanceValue !== null
+    ? formatDistanceAxisTick(distanceValue, distanceUnit)
+    : formatRelTime(relMs);
+  const badges = [formatAbsTime(baseTimestampMs, relMs)];
+
+  if (mode === "distance") {
+    badges.unshift(formatRelTime(relMs));
+  } else if (distanceValue !== null) {
+    badges.push(formatDistanceAxisTick(distanceValue, distanceUnit));
+  }
+
+  return `<div style="display:flex;align-items:center;gap:6px;flex-wrap:wrap;"><strong>${primary}</strong>${badges.map((label) => `<span style="display:inline-flex;align-items:center;border-radius:999px;padding:1px 6px;font-size:11px;background:rgba(148,163,184,0.22);">${label}</span>`).join("")}</div>`;
+}
+
+function distanceAtTimestamp(records: RecordPoint[], timestampMs: number): number | null {
+  let before: RecordPoint | null = null;
+  let after: RecordPoint | null = null;
+
+  for (const record of records) {
+    if (record.timestamp_ms <= timestampMs) {
+      before = record;
+    }
+    if (record.timestamp_ms >= timestampMs) {
+      after = record;
+      break;
+    }
+  }
+
+  const beforeDistance = before ? finiteDistanceMeters(before) : null;
+  const afterDistance = after ? finiteDistanceMeters(after) : null;
+
+  if (before && after && beforeDistance !== null && afterDistance !== null) {
+    if (after.timestamp_ms === before.timestamp_ms) return beforeDistance;
+    const ratio = Math.max(0, Math.min(1, (timestampMs - before.timestamp_ms) / (after.timestamp_ms - before.timestamp_ms)));
+    return beforeDistance + (afterDistance - beforeDistance) * ratio;
+  }
+
+  if (beforeDistance !== null && afterDistance !== null) {
+    return Math.abs(timestampMs - (before?.timestamp_ms ?? timestampMs)) <= Math.abs(timestampMs - (after?.timestamp_ms ?? timestampMs))
+      ? beforeDistance
+      : afterDistance;
+  }
+
+  return beforeDistance ?? afterDistance;
+}
+
+export function buildLapMarkers(
+  records: RecordPoint[],
+  lapTimestampsUtc: string[],
+  startTimestampMs: number,
+  mode: TelemetryXAxisMode,
+  distanceUnit: DistanceUnit,
+): LapMarker[] {
+  return lapTimestampsUtc
+    .slice(1)
+    .map((timestamp, idx) => {
+      const parsed = Date.parse(timestamp);
+      if (!Number.isFinite(parsed)) return null;
+
+      if (mode === "distance") {
+        const distanceMeters = distanceAtTimestamp(records, parsed);
+        if (distanceMeters === null) return null;
+        return { xAxis: convertDistanceMeters(distanceMeters, distanceUnit), name: `Lap ${idx + 1}` };
+      }
+
+      const relMs = parsed - startTimestampMs;
+      if (relMs < 0) return null;
+      return { xAxis: relMs, name: `Lap ${idx + 1}` };
+    })
+    .filter((marker): marker is LapMarker => marker !== null);
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1373,6 +1373,44 @@ button:focus-visible {
   margin: 0;
 }
 
+.detail-axis-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 2px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--input-bg);
+}
+
+.detail-axis-toggle button {
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 0.72rem;
+  font-weight: 700;
+  line-height: 1;
+  padding: 0.28rem 0.55rem;
+  transition: all 160ms ease;
+}
+
+.detail-axis-toggle button.active {
+  background: var(--accent);
+  color: white;
+  box-shadow: 0 2px 8px var(--accent-glow);
+}
+
+.detail-axis-toggle button:not(.active):not(:disabled):hover {
+  color: var(--text);
+  background: var(--accent-glow);
+}
+
+.detail-axis-toggle button:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
 .badge {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary

- add a Time / Distance x-axis toggle for individual activity telemetry charts
- apply the distance axis to eligible line charts while leaving histograms, scatter plots, zone charts, and the effort heatmap unchanged
- add shared telemetry-axis helpers for distance ticks, tooltip context, and lap marker positioning
- document the chart distance-axis design

## Validation

- `npm run build`
- `git diff --check upstream/main`

Closes #38
