### PR TITLE
Add FIT device metadata and accessory display labels

### DIFF
--- a/docs/features/fit-device-accessory-metadata.md
+++ b/docs/features/fit-device-accessory-metadata.md
@@ -51,6 +51,13 @@ compatibility. Keep the existing top-level `metadata_json.file_id` object for
 current readers, but enrich `metadata_json.device_info` with a versioned full
 list of devices discovered in the FIT file.
 
+Persist raw and FIT-profile-derived facts in `metadata_json`: numeric codes,
+SDK enum names when available, source type, device type, manufacturer, serial
+number, identifiers, and timestamps. Product substitutions and user-facing
+labels that are not directly provided by the FIT profile should be derived in
+the UI/export layer so improved lookup tables can apply to old rows without a
+metadata backfill.
+
 Suggested metadata shape:
 
 ```json
@@ -119,9 +126,9 @@ Suggested metadata shape:
         "product": {
           "field": "garmin_product",
           "code": 4606,
-          "name": "hrm_200",
-          "label": "HRM 200",
-          "lookup_source": "app_overlay"
+          "name": null,
+          "label": null,
+          "lookup_source": "raw"
         },
         "serial_number": 3618094325,
         "software_version": "5.40",
@@ -198,19 +205,21 @@ Suggested metadata shape:
 }
 ```
 
-Use `name` for stable enum-style identifiers and `label` for human display text.
-Use `code` for the raw numeric FIT value when available. The `fitparser` API
-returns decoded strings for many known profile values and does not expose a
-separate raw value, so implementation should reverse-map known decoded strings
-through the generated FIT enum helpers. Reverse mapping must use a round-trip
-guard, such as checking that converting the numeric enum back to a string matches
-the original decoded name, to avoid treating unknown strings as valid code `0`.
-Preserve numeric codes when they are already present, especially unresolved
-products such as Garmin product `4606` or Magene product `3`.
+Use `code` for the raw numeric FIT value when available. Use `name` only for
+stable enum-style identifiers supplied by the FIT profile or recovered through a
+guarded reverse lookup. The `fitparser` API returns decoded strings for many
+known profile values and does not expose a separate raw value, so implementation
+should reverse-map known decoded strings through the generated FIT enum helpers.
+Reverse mapping must use a round-trip guard, such as checking that converting
+the numeric enum back to a string matches the original decoded name, to avoid
+treating unknown strings as valid code `0`. Preserve numeric codes when they are
+already present, especially unresolved products such as Garmin product `4606`,
+Garmin product `3592`, or Magene product `3`.
 
-Product labels should omit the manufacturer because manufacturer is stored in a
-separate structured field. The UI can compose full labels such as `Garmin HRM
-200` from `manufacturer.label` and `product.label`.
+`label` values in persisted metadata are compatibility/display hints, not the
+source of truth. New manual substitutions should not be written as persisted
+product names or labels. The UI can compose full labels such as `Garmin HRM 200`
+from manufacturer facts, product codes, source type, and device type.
 
 The `devices[]` entries represent physical devices, not raw FIT records. When a
 single physical accessory appears with multiple functions, such as radar and
@@ -263,32 +272,43 @@ manufacturer `favero_electronics` with product code `12` resolves to
 `assioma_duo`, while the same product code would mean something different under
 another manufacturer.
 
-Supplement FIT profile lookups with a small app-owned overlay table for products
-that the current SDK does not name yet. The overlay key must be exact:
+Supplement FIT profile lookups with a small app-owned display lookup table for
+products that the current SDK does not name yet. These entries should be applied
+by the UI/export resolver, not by rewriting persisted product names. The display
+lookup key should be exact and may include context when a code is ambiguous:
 
 ```text
-manufacturer + product_field + product_code
+manufacturer + product_field + product_code + source_type + device_type
 ```
 
-Example overlay entry:
+Example display lookup entries:
 
 ```text
-garmin + garmin_product + 4606 -> name: hrm_200, label: HRM 200
+garmin + garmin_product + 4606 + any + heart_rate -> HRM 200
+garmin + garmin_product/product + 255 + antplus + heart_rate -> HRM 200
+garmin + garmin_product/product + 3592 + antplus + bike_radar/bike_light_main -> Varia RTL515
 ```
 
-Resolution order:
+Persistence resolution order:
 
 1. Use the FIT SDK/profile result when it provides a usable product name. Populate
    `code` by reverse-mapping decoded strings through the matching generated enum
    helper when the raw numeric value is not exposed directly.
-2. Use the app overlay when the SDK result is numeric, missing, or unknown. Store
-   the raw numeric `code` that triggered the overlay.
-3. Preserve the raw product code with `name: null`, `label: null`, and
-   `lookup_source: "raw"` when neither lookup resolves it.
+2. Preserve the raw product code with `name: null`, `label: null`, and
+   `lookup_source: "raw"` when the FIT profile does not resolve it.
+3. Do not persist app-owned display substitutions as authoritative product
+   names. Keep raw product codes even when a display lookup succeeds.
 
-Overlay entries fill SDK gaps by default; they should not override a usable SDK
-name unless a future entry explicitly opts into that behaviour. Keep raw product
-codes even when a lookup succeeds.
+Display/export resolution order:
+
+1. Use an app-owned display lookup when a raw product code plus context identifies
+   a more useful device name.
+2. Use the FIT SDK/profile product name when available.
+3. Fall back to manufacturer plus device type.
+4. Fall back to raw product code.
+
+Display lookup entries fill SDK gaps by default; they should not override a
+usable SDK name unless a future entry explicitly opts into that behaviour.
 
 Reverse mapping helpers should be centralized and covered by tests. Test cases
 should include known values with code `0`, unknown strings that would otherwise
@@ -301,21 +321,29 @@ Product metadata fields:
   or generic `product`
 - `code`: raw numeric product code, from the parser when exposed directly or from
   guarded reverse mapping when the parser exposes a decoded string
-- `name`: stable enum-style identifier, such as `hrm_200`
-- `label`: human product label without manufacturer, such as `HRM 200`
-- `lookup_source`: `fit_profile`, `app_overlay`, or `raw`
+- `name`: stable FIT-profile enum-style identifier when known, such as
+  `assioma_duo`; unresolved product codes should keep `name: null`
+- `label`: optional compatibility/display hint; manual substitutions should be
+  derived in UI/export rather than persisted here
+- `lookup_source`: `fit_profile` or `raw`
 
 Display fallback order for a full accessory label:
 
-1. `manufacturer.label` + `product.label`
-2. `manufacturer.label` + device type label
+1. derived manufacturer label + derived product label from the display lookup or
+   FIT profile name
+2. derived manufacturer label + device type label
 3. device type label
 4. `Unknown accessory`
 
 Examples from observed files:
 
-- Garmin product code `4606` with BLE type `heart_rate` resolves through the app
-  overlay to `Garmin HRM 200`.
+- Garmin product code `4606` with BLE type `heart_rate` remains raw product code
+  metadata, but displays as `Garmin HRM 200`.
+- Garmin product code `255` with ANT+ type `heart_rate` may be decoded by the SDK
+  as `OHR`; when it is an external ANT+/Bluetooth heart-rate accessory, display
+  it as `Garmin HRM 200`.
+- Garmin product code `3592` with ANT+ `bike_radar` and `bike_light_main` records
+  remains raw product code metadata, but displays as `Garmin Varia RTL515`.
 - Magene product code `3` with ANT+ type `bike_speed` remains raw product code
   metadata, but displays as `Magene bike speed sensor`.
 - Magene product code `3` with ANT+ type `bike_cadence` remains raw product code
@@ -377,8 +405,10 @@ accessories are present, the hover state should stay minimal rather than showing
 an empty accessory section.
 
 JSON export should include the enriched device metadata while preserving the
-existing `activity.device` field. Add a root-level `deviceInfo` object to the
-export and add a device metadata version to `_exportInfo`:
+existing `activity.device` field. Device entries should include raw/parsed
+metadata plus a derived `display` object so exports are readable without making
+friendly labels the persisted source of truth. Add a root-level `deviceInfo`
+object to the export and add a device metadata version to `_exportInfo`:
 
 ```json
 {
@@ -391,7 +421,17 @@ export and add a device metadata version to `_exportInfo`:
   },
   "deviceInfo": {
     "sourceSupport": "full",
-    "primary": [],
+    "primary": [
+      {
+        "role": "primary",
+        "display": {
+          "name": "Garmin Edge 1040",
+          "manufacturer": "Garmin",
+          "product": "Edge 1040",
+          "deviceType": null
+        }
+      }
+    ],
     "accessories": [],
     "internal": []
   }

--- a/docs/features/fit-device-accessory-metadata.md
+++ b/docs/features/fit-device-accessory-metadata.md
@@ -1,0 +1,474 @@
+# FIT Device and Accessory Metadata
+
+## Problem
+
+FIT activity files can include more than one device. A single activity may be
+recorded by a primary watch or cycling computer while also receiving data from
+accessories such as a heart rate monitor, power meter, speed sensor, radar, or
+light.
+
+The current app persists one display device string on `activities.device`. It
+also keeps a small amount of device metadata in `metadata_json`, but that
+metadata only tracks a creator device and a fallback device. Accessory records
+are not preserved for export or UI display.
+
+This makes the exported JSON incomplete for users who want to know which sensors
+contributed to an activity, and it can make the activity header misleading when
+a serial number is shown without enough context.
+
+## Current Behaviour
+
+During FIT import, the parser inspects `file_id` and `device_info` messages.
+The persisted `activities.device` value is selected using this priority:
+
+1. `device_info` where `device_index` is `creator` or numeric `0`
+2. `file_id` manufacturer/product
+3. first available `device_info` record
+
+The current metadata shape is effectively:
+
+```json
+{
+  "file_id": {
+    "product_name": "garmin edge_1040",
+    "serial_number": 1234567890
+  },
+  "device_info": {
+    "creator_product_name": "garmin edge_1040",
+    "creator_serial_number": 1234567890,
+    "fallback_product_name": "garmin edge_1040",
+    "fallback_serial_number": 1234567890
+  }
+}
+```
+
+This loses the complete list of `device_info` records.
+
+## Proposed Solution
+
+Keep `activities.device` as the primary recorder display string for backward
+compatibility. Keep the existing top-level `metadata_json.file_id` object for
+current readers, but enrich `metadata_json.device_info` with a versioned full
+list of devices discovered in the FIT file.
+
+Suggested metadata shape:
+
+```json
+{
+  "file_id": {
+    "product_name": "garmin edge_1040",
+    "serial_number": 3609441582
+  },
+  "device_info": {
+    "schema_version": 1,
+    "source_support": "full",
+    "creator_product_name": "garmin edge_1040",
+    "creator_serial_number": 3609441582,
+    "fallback_product_name": "garmin edge_1040",
+    "fallback_serial_number": 3609441582,
+    "decoded_file_id": {
+      "manufacturer": { "code": 1, "name": "garmin", "label": "Garmin" },
+      "product": {
+        "field": "garmin_product",
+        "code": 3843,
+        "name": "edge_1040",
+        "label": "Edge 1040",
+        "lookup_source": "fit_profile"
+      },
+      "serial_number": 3609441582,
+      "time_created_utc": "2026-06-11T14:21:20Z"
+    },
+    "devices": [
+      {
+        "role": "primary",
+        "device_indices": ["creator"],
+        "source_type": { "code": 5, "name": "local", "label": "Local" },
+        "device_types": [],
+        "manufacturer": { "code": 1, "name": "garmin", "label": "Garmin" },
+        "product": {
+          "field": "garmin_product",
+          "code": 3843,
+          "name": "edge_1040",
+          "label": "Edge 1040",
+          "lookup_source": "fit_profile"
+        },
+        "serial_number": 3609441582,
+        "software_version": "31.30",
+        "hardware_version": null,
+        "battery_status": null,
+        "battery_level": null,
+        "identifiers": {
+          "ant_device_number": null,
+          "ant_transmission_type": null,
+          "ant_network": null,
+          "descriptor": null
+        },
+        "first_seen_utc": "2026-06-11T14:21:20Z",
+        "last_seen_utc": "2026-06-11T18:57:53Z"
+      },
+      {
+        "role": "accessory",
+        "device_indices": [3],
+        "source_type": {
+          "code": 3,
+          "name": "bluetooth_low_energy",
+          "label": "Bluetooth Low Energy"
+        },
+        "device_types": [{ "code": 1, "name": "heart_rate", "label": "Heart Rate" }],
+        "manufacturer": { "code": 1, "name": "garmin", "label": "Garmin" },
+        "product": {
+          "field": "garmin_product",
+          "code": 4606,
+          "name": "hrm_200",
+          "label": "HRM 200",
+          "lookup_source": "app_overlay"
+        },
+        "serial_number": 3618094325,
+        "software_version": "5.40",
+        "hardware_version": 66,
+        "battery_status": "good",
+        "battery_level": 80,
+        "identifiers": {
+          "ant_device_number": null,
+          "ant_transmission_type": null,
+          "ant_network": "antplus",
+          "descriptor": null
+        },
+        "first_seen_utc": "2026-06-11T14:21:20Z",
+        "last_seen_utc": "2026-06-11T18:57:53Z"
+      },
+      {
+        "role": "accessory",
+        "device_indices": [4],
+        "source_type": { "code": 1, "name": "antplus", "label": "ANT+" },
+        "device_types": [{ "code": 11, "name": "bike_power", "label": "Power Meter" }],
+        "manufacturer": { "code": 263, "name": "favero_electronics", "label": "Favero" },
+        "product": {
+          "field": "favero_product",
+          "code": 12,
+          "name": "assioma_duo",
+          "label": "Assioma Duo",
+          "lookup_source": "fit_profile"
+        },
+        "serial_number": 2368736719,
+        "software_version": "6.24",
+        "hardware_version": 4,
+        "battery_status": "ok",
+        "battery_voltage": 3.86328125,
+        "identifiers": {
+          "ant_device_number": null,
+          "ant_transmission_type": null,
+          "ant_network": "antplus",
+          "descriptor": null
+        },
+        "first_seen_utc": "2026-06-11T14:21:20Z",
+        "last_seen_utc": "2026-06-11T18:57:53Z"
+      },
+      {
+        "role": "accessory",
+        "device_indices": [5, 6],
+        "source_type": { "code": 1, "name": "antplus", "label": "ANT+" },
+        "device_types": [
+          { "code": 35, "name": "bike_light_main", "label": "Bike Light" },
+          { "code": 40, "name": "bike_radar", "label": "Bike Radar" }
+        ],
+        "manufacturer": { "code": 1, "name": "garmin", "label": "Garmin" },
+        "product": {
+          "field": "garmin_product",
+          "code": 3592,
+          "name": null,
+          "label": null,
+          "lookup_source": "raw"
+        },
+        "serial_number": 3604924594,
+        "software_version": "3.36",
+        "hardware_version": 66,
+        "identifiers": {
+          "ant_device_number": null,
+          "ant_transmission_type": null,
+          "ant_network": "antplus",
+          "descriptor": null
+        },
+        "first_seen_utc": "2026-06-11T14:21:20Z",
+        "last_seen_utc": "2026-06-11T18:57:53Z"
+      }
+    ],
+    "raw_device_info_record_count": 12
+  }
+}
+```
+
+Use `name` for stable enum-style identifiers and `label` for human display text.
+Use `code` for the raw numeric FIT value when available. The `fitparser` API
+returns decoded strings for many known profile values and does not expose a
+separate raw value, so implementation should reverse-map known decoded strings
+through the generated FIT enum helpers. Reverse mapping must use a round-trip
+guard, such as checking that converting the numeric enum back to a string matches
+the original decoded name, to avoid treating unknown strings as valid code `0`.
+Preserve numeric codes when they are already present, especially unresolved
+products such as Garmin product `4606` or Magene product `3`.
+
+Product labels should omit the manufacturer because manufacturer is stored in a
+separate structured field. The UI can compose full labels such as `Garmin HRM
+200` from `manufacturer.label` and `product.label`.
+
+The `devices[]` entries represent physical devices, not raw FIT records. When a
+single physical accessory appears with multiple functions, such as radar and
+light, merge it into one entry with multiple `device_types` and `device_indices`
+only when stable identifiers show that the records came from the same physical
+device. Separate lights, radars, or sensor units must remain separate entries.
+
+## Classification Rules
+
+Use FIT `device_info` fields to classify records:
+
+- `role: "primary"` when `device_index` is `creator` or numeric `0`
+- `role: "accessory"` when `device_index` is not creator/0 and decoded
+  `source_type` is `antplus`, `bluetooth`, or `bluetooth_low_energy`
+- `role: "internal"` when `device_index` is not creator/0 and decoded
+  `source_type` is `local`
+
+The FIT profile exposes source-specific device type fields. Normalise them into
+`device_types[]` based on `source_type`:
+
+- `source_type=antplus`: use `antplus_device_type`
+- `source_type=bluetooth_low_energy`: use `ble_device_type`
+- `source_type=local`: use `local_device_type`
+- unknown source: preserve the raw `device_type` code with `name: null`
+
+Examples:
+
+- `source_type=local`, `device_index=creator`, Garmin product `edge_1040`:
+  primary recorder
+- `source_type=bluetooth_low_energy`, `device_types=["heart_rate"]`: accessory
+  heart rate monitor
+- `source_type=antplus`, `device_types=["bike_power"]`: accessory power meter
+- `source_type=local`, `device_types=["gps"]`: internal device component
+
+## Lookup Tables
+
+The app can use the generated FIT profile data already available through
+`fitparser`:
+
+- `Manufacturer`
+- `GarminProduct`
+- `FaveroProduct`
+- `AntplusDeviceType`
+- `BleDeviceType`
+- `LocalDeviceType`
+- `SourceType`
+
+Product codes must be decoded in a manufacturer-specific way. For example,
+manufacturer `favero_electronics` with product code `12` resolves to
+`assioma_duo`, while the same product code would mean something different under
+another manufacturer.
+
+Supplement FIT profile lookups with a small app-owned overlay table for products
+that the current SDK does not name yet. The overlay key must be exact:
+
+```text
+manufacturer + product_field + product_code
+```
+
+Example overlay entry:
+
+```text
+garmin + garmin_product + 4606 -> name: hrm_200, label: HRM 200
+```
+
+Resolution order:
+
+1. Use the FIT SDK/profile result when it provides a usable product name. Populate
+   `code` by reverse-mapping decoded strings through the matching generated enum
+   helper when the raw numeric value is not exposed directly.
+2. Use the app overlay when the SDK result is numeric, missing, or unknown. Store
+   the raw numeric `code` that triggered the overlay.
+3. Preserve the raw product code with `name: null`, `label: null`, and
+   `lookup_source: "raw"` when neither lookup resolves it.
+
+Overlay entries fill SDK gaps by default; they should not override a usable SDK
+name unless a future entry explicitly opts into that behaviour. Keep raw product
+codes even when a lookup succeeds.
+
+Reverse mapping helpers should be centralized and covered by tests. Test cases
+should include known values with code `0`, unknown strings that would otherwise
+fall through to `0`, and manufacturer-specific product fields such as
+`garmin_product` and `favero_product`.
+
+Product metadata fields:
+
+- `field`: FIT product field name, such as `garmin_product`, `favero_product`,
+  or generic `product`
+- `code`: raw numeric product code, from the parser when exposed directly or from
+  guarded reverse mapping when the parser exposes a decoded string
+- `name`: stable enum-style identifier, such as `hrm_200`
+- `label`: human product label without manufacturer, such as `HRM 200`
+- `lookup_source`: `fit_profile`, `app_overlay`, or `raw`
+
+Display fallback order for a full accessory label:
+
+1. `manufacturer.label` + `product.label`
+2. `manufacturer.label` + device type label
+3. device type label
+4. `Unknown accessory`
+
+Examples from observed files:
+
+- Garmin product code `4606` with BLE type `heart_rate` resolves through the app
+  overlay to `Garmin HRM 200`.
+- Magene product code `3` with ANT+ type `bike_speed` remains raw product code
+  metadata, but displays as `Magene bike speed sensor`.
+- Magene product code `3` with ANT+ type `bike_cadence` remains raw product code
+  metadata, but displays as `Magene bike cadence sensor`.
+
+TCX and GPX files should use the same metadata envelope when possible, but they
+usually provide less device data:
+
+- FIT: `source_support: "full"` when `device_info` records are available
+- TCX: `source_support: "primary_only"` when only `Activity/Creator` is
+  available
+- GPX: `source_support: "creator_only"` when only the GPX `creator` string is
+  available
+- no useful source metadata: `source_support: "none"` and `devices: []`
+
+## De-duplication
+
+FIT files often repeat `device_info` records at the start and end of an
+activity. De-duplicate device entries by the strongest stable identity fields
+available:
+
+- serial number when present and greater than zero, scoped by manufacturer,
+  product, and source type
+- ANT identifiers when present: `ant_device_number`, `ant_transmission_type`,
+  and `ant_network`
+- BLE descriptor or address-like identifiers when available
+- device index, when needed to avoid merging distinct components or records
+  without stable serial/ANT/BLE identity
+
+Use device type as classification and fallback identity only. It should not
+prevent merging multiple functions from the same physical device when stable
+identifiers match, and it should not cause separate physical devices to merge
+solely because they share a manufacturer/product/source type.
+
+For duplicate records, keep a single device entry and merge useful changing
+fields:
+
+- earliest timestamp as `first_seen_utc`
+- latest timestamp as `last_seen_utc`
+- latest non-null battery level/status
+- latest software and hardware versions
+- union of `device_indices`
+- union of `device_types`
+
+If serial number is missing or `0`, do not use it as a unique identity. Fall
+back to source-specific identifiers first, then to manufacturer/product/source
+type/device type/device index.
+
+## UI and Export Behaviour
+
+The activity header should show the primary display device, such as
+`Garmin Edge 1040`, not a serial number. Serial numbers may be included in
+metadata and export, but should not be the compact display label.
+
+The primary device label can expose accessory details on hover or keyboard
+focus. The tooltip or popover should list accessory display labels grouped by
+type, such as heart rate monitor, power meter, radar, and lights. When no
+accessories are present, the hover state should stay minimal rather than showing
+an empty accessory section.
+
+JSON export should include the enriched device metadata while preserving the
+existing `activity.device` field. Add a root-level `deviceInfo` object to the
+export and add a device metadata version to `_exportInfo`:
+
+```json
+{
+  "_exportInfo": {
+    "format": "FIT Dashboard JSON Export",
+    "deviceMetadataVersion": 1
+  },
+  "activity": {
+    "device": "garmin edge_1040"
+  },
+  "deviceInfo": {
+    "sourceSupport": "full",
+    "primary": [],
+    "accessories": [],
+    "internal": []
+  }
+}
+```
+
+CSV export can remain unchanged initially, or include a compact accessories
+summary later.
+
+Potential UI grouping:
+
+- Primary device
+- Accessories
+- Internal sensors
+
+Accessory display order should be deterministic:
+
+1. heart rate
+2. power
+3. cadence
+4. speed
+5. speed/cadence combo
+6. radar
+7. lights
+8. shifting/drivetrain
+9. temperature
+10. other sensors and accessories
+
+Within the same accessory type, sort by display label, then manufacturer/product,
+then serial number when present, then first `device_index`. JSON export should
+use the same order as the UI so repeated exports are stable.
+
+## Database and Migration
+
+This feature can be added without a DuckDB table migration because the richer
+structure fits inside existing `metadata_json`.
+
+For a new database:
+
+- the existing `activities` schema is created as it is today
+- new imports write `metadata_json.device_info.schema_version = 1`
+- new imports write `metadata_json.device_info.devices[]`
+- `activities.device` continues to store the primary display device
+
+For an existing database:
+
+- no schema migration is required
+- old rows may have no `device_info.devices` array
+- UI and export code must tolerate missing `schema_version` and missing
+  `devices[]`
+- old rows continue to use `activities.device` and legacy
+  `device_info.creator_*` / `device_info.fallback_*` metadata
+- no backfill is included in the initial implementation
+
+Backfill is a possible future item. In this context, backfill would mean
+re-parsing persisted source files and updating existing rows with newly derived
+metadata without deleting and re-importing the activity. It would scan the
+configured FIT files directory, compute file hashes, match those hashes to
+existing activities, and update only `metadata_json`. Filenames could be used as
+hints, but not as the primary identity.
+
+Any future backfill must preserve user-entered fields, especially
+`activities.activity_name`, because users can rename stored activities from the
+activity list. A delete-and-re-import strategy would overwrite those names with
+FIT-derived names and may also disturb activity IDs, delete blacklist state, or
+other local references. Future imports of new activities will produce the new
+metadata, but already-imported activities need an explicit metadata refresh or
+future backfill because normal duplicate detection should leave existing rows
+unchanged.
+
+Existing consumers of top-level exported `activity.device` should continue to
+work unchanged, and existing consumers of top-level `metadata_json.file_id`
+should continue to find that field.
+
+## Open Questions
+
+- Should existing activities be backfilled opportunistically from stored FIT
+  files when available?
+- Should internal `local` device components be shown in the UI by default, or
+  only in expanded/debug views?

--- a/docs/features/fit-device-accessory-metadata.md
+++ b/docs/features/fit-device-accessory-metadata.md
@@ -347,12 +347,17 @@ Display/export resolution order:
 
 1. Use an app-owned display lookup when a raw product code plus context identifies
    a more useful device name.
-2. Use the FIT SDK/profile product name when available.
+2. Use the FIT SDK/profile product name when available and it is not a generic
+   unresolved label such as `Product 3`.
 3. Fall back to manufacturer plus device type.
-4. Fall back to raw product code.
+4. Fall back to device type when no manufacturer is available.
+5. Fall back to manufacturer plus raw product code, or raw product code alone,
+   only when no useful device type is available.
 
 Display lookup entries fill SDK gaps by default; they should not override a
-usable SDK name unless a future entry explicitly opts into that behaviour.
+usable SDK name unless a future entry explicitly opts into that behaviour. Generic
+`Product #` labels are considered unresolved display labels, not useful SDK
+names, and should never outrank device type labels.
 
 Reverse mapping helpers should be centralized and covered by tests. Test cases
 should include known values with code `0`, unknown strings that would otherwise
@@ -407,9 +412,11 @@ Examples from observed files:
 - Garmin product code `3592` with ANT+ `bike_radar` and `bike_light_main` records
   remains raw product code metadata, but displays as `Garmin Varia RTL515`.
 - Magene product code `3` with ANT+ type `bike_speed` remains raw product code
-  metadata, but displays as `Magene bike speed sensor`.
+  metadata, but displays as `Magene Speed Sensor`.
 - Magene product code `3` with ANT+ type `bike_cadence` remains raw product code
-  metadata, but displays as `Magene bike cadence sensor`.
+  metadata, but displays as `Magene Cadence Sensor`.
+- Product code `3` with no manufacturer and ANT+ type `bike_cadence` remains raw
+  product code metadata, but displays as `Cadence Sensor`.
 
 TCX and GPX files should use the same metadata envelope when possible, but they
 usually provide less device data:

--- a/docs/features/fit-device-accessory-metadata.md
+++ b/docs/features/fit-device-accessory-metadata.md
@@ -16,6 +16,13 @@ This makes the exported JSON incomplete for users who want to know which sensors
 contributed to an activity, and it can make the activity header misleading when
 a serial number is shown without enough context.
 
+Sparse Garmin Stopwatch/manual-timer FIT files expose another edge case. They
+may contain `sport.name = Stopwatch` while `session.sport` remains the numeric
+value `52`, and their single `device_info` record may omit `device_index`,
+`source_type`, and `device_type`. In that case the app can leak both raw activity
+type `52` and raw device text such as `garmin fr255` even though the file has
+enough metadata to display `Stopwatch` and `Garmin Forerunner 255`.
+
 ## Current Behaviour
 
 During FIT import, the parser inspects `file_id` and `device_info` messages.
@@ -24,6 +31,34 @@ The persisted `activities.device` value is selected using this priority:
 1. `device_info` where `device_index` is `creator` or numeric `0`
 2. `file_id` manufacturer/product
 3. first available `device_info` record
+
+For sparse files where `device_info` lacks a creator index and source type, the
+new device list can classify the record as `unknown` rather than `primary`.
+Current UI fallback can then use the legacy `activities.device` string, which is
+built from raw FIT enum names such as `garmin fr255`.
+
+The FIT parser also currently reads activity type from the `session` message but
+does not use the FIT `sport` message. Stopwatch/manual-timer activities observed
+from Garmin use:
+
+```text
+sport.name = Stopwatch
+sport.sport = 52
+session.sport = 52
+session.sub_sport = generic
+activity.type = manual
+file_id.manufacturer = garmin
+file_id.garmin_product = fr255
+device_info.manufacturer = garmin
+device_info.garmin_product = fr255
+device_info.device_index = null
+device_info.source_type = null
+device_info.device_type = null
+```
+
+The app should treat `sport.name = Stopwatch` as the meaningful activity-type
+label when the session sport is numeric or otherwise unresolved. It should not
+depend on a UI-only substitution for `52`.
 
 The current metadata shape is effectively:
 
@@ -57,6 +92,15 @@ number, identifiers, and timestamps. Product substitutions and user-facing
 labels that are not directly provided by the FIT profile should be derived in
 the UI/export layer so improved lookup tables can apply to old rows without a
 metadata backfill.
+
+For FIT activity type classification, also capture the FIT `sport` message name
+when present. If `session.sport` is numeric, unknown, or unresolved, and
+`sport.name` is a meaningful string such as `Stopwatch`, use that value for the
+canonical stored `activities.sport`, generated `activities.activity_name`, and
+`metadata_json.sport`. Preserve the original numeric session sport in metadata
+for diagnostics, for example `metadata_json.raw_sport_code = 52` or an
+equivalent `metadata_json.session.raw_sport_code` field. This keeps newly
+imported rows correct at the parser layer while retaining the raw FIT fact.
 
 Suggested metadata shape:
 
@@ -335,10 +379,28 @@ Display fallback order for a full accessory label:
 3. device type label
 4. `Unknown accessory`
 
+Primary device display fallback order:
+
+1. primary device entry from `metadata_json.device_info.devices[]`
+2. decoded `metadata_json.device_info.decoded_file_id` manufacturer/product
+   label, such as `Garmin Forerunner 255`
+3. legacy `activities.device`
+4. legacy `metadata_json.file_id.product_name`
+5. empty string
+
+This matters for sparse Stopwatch/manual-timer FIT files where `device_info`
+contains Garmin product `fr255` but lacks enough role fields to classify the
+record as `primary`. The UI and JSON export should still prefer the decoded
+file-id label over raw legacy text like `garmin fr255`.
+
 Examples from observed files:
 
 - Garmin product code `4606` with BLE type `heart_rate` remains raw product code
   metadata, but displays as `Garmin HRM 200`.
+- Garmin Forerunner 255 Stopwatch/manual-timer files may provide
+  `file_id.garmin_product = fr255` and a `device_info` record with the same
+  product but no `device_index`, `source_type`, or `device_type`; display the
+  primary device as `Garmin Forerunner 255` using the decoded file-id fallback.
 - Garmin product code `255` with ANT+ type `heart_rate` may be decoded by the SDK
   as `OHR`; when it is an external ANT+/Bluetooth heart-rate accessory, display
   it as `Garmin HRM 200`.

--- a/src-tauri/src/device_metadata.rs
+++ b/src-tauri/src/device_metadata.rs
@@ -1,0 +1,743 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use fitparser::profile::field_types::{
+    AntNetwork, AntplusDeviceType, BleDeviceType, FaveroProduct, GarminProduct, LocalDeviceType,
+    Manufacturer, SourceType,
+};
+use serde::Serialize;
+use serde_json::Value as JsonValue;
+
+#[derive(Clone, Debug, Default)]
+pub struct RawFileId {
+    pub manufacturer_value: Option<String>,
+    pub product_field: Option<String>,
+    pub product_value: Option<String>,
+    pub serial_number: Option<i64>,
+    pub time_created_ms: Option<i64>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct RawDeviceType {
+    pub field: String,
+    pub value: String,
+    pub code: Option<i64>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct RawDeviceInfo {
+    pub timestamp_ms: Option<i64>,
+    pub device_index_value: Option<String>,
+    pub device_index_code: Option<i64>,
+    pub source_type_value: Option<String>,
+    pub source_type_code: Option<i64>,
+    pub device_types: Vec<RawDeviceType>,
+    pub manufacturer_value: Option<String>,
+    pub product_field: Option<String>,
+    pub product_value: Option<String>,
+    pub product_name: Option<String>,
+    pub serial_number: Option<i64>,
+    pub software_version: Option<String>,
+    pub hardware_version: Option<i64>,
+    pub battery_status: Option<String>,
+    pub battery_level: Option<f64>,
+    pub battery_voltage: Option<f64>,
+    pub ant_device_number: Option<i64>,
+    pub ant_transmission_type: Option<i64>,
+    pub ant_network_value: Option<String>,
+    pub ant_network_code: Option<i64>,
+    pub descriptor: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq)]
+pub struct CodeNameLabel {
+    pub code: Option<i64>,
+    pub name: Option<String>,
+    pub label: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq)]
+pub struct ProductMetadata {
+    pub field: Option<String>,
+    pub code: Option<i64>,
+    pub name: Option<String>,
+    pub label: Option<String>,
+    pub lookup_source: String,
+}
+
+#[derive(Clone, Debug, Default, Serialize, PartialEq)]
+pub struct DeviceIdentifiers {
+    pub ant_device_number: Option<i64>,
+    pub ant_transmission_type: Option<i64>,
+    pub ant_network: Option<String>,
+    pub descriptor: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq)]
+pub struct DeviceMetadata {
+    pub role: String,
+    pub device_indices: Vec<JsonValue>,
+    pub source_type: CodeNameLabel,
+    pub device_types: Vec<CodeNameLabel>,
+    pub manufacturer: CodeNameLabel,
+    pub product: ProductMetadata,
+    pub serial_number: Option<i64>,
+    pub software_version: Option<String>,
+    pub hardware_version: Option<i64>,
+    pub battery_status: Option<String>,
+    pub battery_level: Option<f64>,
+    pub battery_voltage: Option<f64>,
+    pub identifiers: DeviceIdentifiers,
+    pub first_seen_utc: Option<String>,
+    pub last_seen_utc: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq)]
+pub struct DecodedFileIdMetadata {
+    pub manufacturer: CodeNameLabel,
+    pub product: ProductMetadata,
+    pub serial_number: Option<i64>,
+    pub time_created_utc: Option<String>,
+}
+
+trait FitEnumCode {
+    fn fit_code(self) -> i64;
+}
+
+impl FitEnumCode for Manufacturer {
+    fn fit_code(self) -> i64 {
+        self.as_i64()
+    }
+}
+
+impl FitEnumCode for GarminProduct {
+    fn fit_code(self) -> i64 {
+        self.as_i64()
+    }
+}
+
+impl FitEnumCode for FaveroProduct {
+    fn fit_code(self) -> i64 {
+        self.as_i64()
+    }
+}
+
+impl FitEnumCode for SourceType {
+    fn fit_code(self) -> i64 {
+        self.as_i64()
+    }
+}
+
+impl FitEnumCode for AntplusDeviceType {
+    fn fit_code(self) -> i64 {
+        self.as_i64()
+    }
+}
+
+impl FitEnumCode for BleDeviceType {
+    fn fit_code(self) -> i64 {
+        self.as_i64()
+    }
+}
+
+impl FitEnumCode for LocalDeviceType {
+    fn fit_code(self) -> i64 {
+        self.as_i64()
+    }
+}
+
+impl FitEnumCode for AntNetwork {
+    fn fit_code(self) -> i64 {
+        self.as_i64()
+    }
+}
+
+fn reverse_fit_enum<T>(name: &str) -> Option<i64>
+where
+    for<'a> T: From<&'a str>,
+    T: FitEnumCode + Copy + ToString,
+{
+    let parsed = T::from(name);
+    if parsed.to_string() == name {
+        Some(parsed.fit_code())
+    } else {
+        None
+    }
+}
+
+fn enum_name_from_code<T>(code: i64) -> Option<String>
+where
+    T: From<i64> + FitEnumCode + Copy + ToString,
+{
+    let parsed = T::from(code);
+    let name = parsed.to_string();
+    if parsed.fit_code() == code && name != code.to_string() && !name.starts_with("unknown_variant_") {
+        Some(name)
+    } else {
+        None
+    }
+}
+
+fn clean_name(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty()
+        || trimmed.chars().all(|c| c.is_ascii_digit())
+        || trimmed.to_lowercase().starts_with("unknown_variant_")
+    {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+fn numeric_code(value: &str) -> Option<i64> {
+    value.trim().parse::<i64>().ok()
+}
+
+fn humanize_identifier(name: &str) -> String {
+    name.split('_')
+        .filter(|part| !part.is_empty())
+        .map(|part| match part.to_ascii_lowercase().as_str() {
+            "ant" => "ANT".to_string(),
+            "antfs" => "ANT-FS".to_string(),
+            "antplus" => "ANT+".to_string(),
+            "ble" => "BLE".to_string(),
+            "bt" => "BT".to_string(),
+            "gps" => "GPS".to_string(),
+            "gnss" => "GNSS".to_string(),
+            "glonass" => "GLONASS".to_string(),
+            "hr" => "HR".to_string(),
+            "hrm" => "HRM".to_string(),
+            "ohr" => "OHR".to_string(),
+            "whr" => "WHR".to_string(),
+            "fr" => "FR".to_string(),
+            "ut" => "UT".to_string(),
+            "duo" => "Duo".to_string(),
+            "uno" => "Uno".to_string(),
+            other => {
+                let mut chars = other.chars();
+                match chars.next() {
+                    Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+                    None => String::new(),
+                }
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn manufacturer_label(name: Option<&str>) -> Option<String> {
+    name.map(|value| match value {
+        "favero_electronics" => "Favero".to_string(),
+        "wahoo_fitness" => "Wahoo".to_string(),
+        "sram" => "SRAM".to_string(),
+        other => humanize_identifier(other),
+    })
+}
+
+fn product_label(name: Option<&str>) -> Option<String> {
+    name.map(|value| match value {
+        "edge_1040" => "Edge 1040".to_string(),
+        "hrm_200" => "HRM 200".to_string(),
+        "assioma_duo" => "Assioma Duo".to_string(),
+        "assioma_uno" => "Assioma Uno".to_string(),
+        other => humanize_identifier(other),
+    })
+}
+
+fn source_type_label(name: Option<&str>) -> Option<String> {
+    name.map(|value| match value {
+        "ant" => "ANT".to_string(),
+        "antplus" => "ANT+".to_string(),
+        "bluetooth" => "Bluetooth".to_string(),
+        "bluetooth_low_energy" => "Bluetooth Low Energy".to_string(),
+        "wifi" => "Wi-Fi".to_string(),
+        "local" => "Local".to_string(),
+        other => humanize_identifier(other),
+    })
+}
+
+fn device_type_label(name: Option<&str>) -> Option<String> {
+    name.map(|value| match value {
+        "heart_rate" => "Heart Rate".to_string(),
+        "bike_power" => "Power Meter".to_string(),
+        "bike_speed_cadence" => "Speed/Cadence Sensor".to_string(),
+        "bike_speed" => "Speed Sensor".to_string(),
+        "bike_cadence" => "Cadence Sensor".to_string(),
+        "bike_light_main" | "bike_light_shared" => "Bike Light".to_string(),
+        "bike_radar" => "Bike Radar".to_string(),
+        "gps" => "GPS".to_string(),
+        "gnss" => "GNSS".to_string(),
+        "barometer" => "Barometer".to_string(),
+        other => humanize_identifier(other),
+    })
+}
+
+fn utc_from_millis(timestamp_ms: i64) -> Option<String> {
+    chrono::DateTime::from_timestamp_millis(timestamp_ms).map(|dt| dt.to_rfc3339())
+}
+
+pub fn resolve_manufacturer(raw: Option<&str>) -> CodeNameLabel {
+    let code = raw.and_then(numeric_code).or_else(|| {
+        raw.and_then(clean_name)
+            .as_deref()
+            .and_then(reverse_fit_enum::<Manufacturer>)
+    });
+    let name = raw
+        .and_then(clean_name)
+        .or_else(|| code.and_then(enum_name_from_code::<Manufacturer>));
+    let label = manufacturer_label(name.as_deref());
+    CodeNameLabel { code, name, label }
+}
+
+fn overlay_product(
+    manufacturer_name: Option<&str>,
+    field: Option<&str>,
+    code: Option<i64>,
+) -> Option<(&'static str, &'static str)> {
+    match (manufacturer_name, field, code) {
+        (Some("garmin"), Some("garmin_product" | "product"), Some(4606)) => {
+            Some(("hrm_200", "HRM 200"))
+        }
+        _ => None,
+    }
+}
+
+pub fn resolve_product(
+    field: Option<&str>,
+    raw: Option<&str>,
+    manufacturer: &CodeNameLabel,
+) -> ProductMetadata {
+    let field = field.map(str::to_string);
+    let field_name = field.as_deref();
+    let raw_name = raw.and_then(clean_name);
+    let code = raw
+        .and_then(numeric_code)
+        .or_else(|| match field_name {
+            Some("garmin_product") => raw_name.as_deref().and_then(reverse_fit_enum::<GarminProduct>),
+            Some("favero_product") => raw_name.as_deref().and_then(reverse_fit_enum::<FaveroProduct>),
+            Some("product") if manufacturer.name.as_deref() == Some("garmin") => {
+                raw_name.as_deref().and_then(reverse_fit_enum::<GarminProduct>)
+            }
+            Some("product") if manufacturer.name.as_deref() == Some("favero_electronics") => {
+                raw_name.as_deref().and_then(reverse_fit_enum::<FaveroProduct>)
+            }
+            _ => None,
+        });
+
+    if let Some((name, label)) = overlay_product(manufacturer.name.as_deref(), field_name, code) {
+        return ProductMetadata {
+            field,
+            code,
+            name: Some(name.to_string()),
+            label: Some(label.to_string()),
+            lookup_source: "app_overlay".to_string(),
+        };
+    }
+
+    let name = raw_name.or_else(|| match field_name {
+        Some("garmin_product") => code.and_then(enum_name_from_code::<GarminProduct>),
+        Some("favero_product") => code.and_then(enum_name_from_code::<FaveroProduct>),
+        Some("product") if manufacturer.name.as_deref() == Some("garmin") => {
+            code.and_then(enum_name_from_code::<GarminProduct>)
+        }
+        Some("product") if manufacturer.name.as_deref() == Some("favero_electronics") => {
+            code.and_then(enum_name_from_code::<FaveroProduct>)
+        }
+        _ => None,
+    });
+    let lookup_source = if name.is_some() && code.is_some() {
+        "fit_profile"
+    } else {
+        "raw"
+    };
+    let label = product_label(name.as_deref());
+    ProductMetadata {
+        field,
+        code,
+        name,
+        label,
+        lookup_source: lookup_source.to_string(),
+    }
+}
+
+fn resolve_source_type(raw: Option<&str>, raw_code: Option<i64>) -> CodeNameLabel {
+    let code = raw_code.or_else(|| {
+        raw.and_then(clean_name)
+            .as_deref()
+            .and_then(reverse_fit_enum::<SourceType>)
+    });
+    let name = raw
+        .and_then(clean_name)
+        .or_else(|| code.and_then(enum_name_from_code::<SourceType>));
+    let label = source_type_label(name.as_deref());
+    CodeNameLabel { code, name, label }
+}
+
+fn resolve_ant_network(raw: Option<&str>, raw_code: Option<i64>) -> Option<String> {
+    raw.and_then(clean_name).or_else(|| {
+        raw_code.and_then(enum_name_from_code::<AntNetwork>)
+    })
+}
+
+fn resolve_device_type(raw_type: &RawDeviceType) -> CodeNameLabel {
+    let raw_name = clean_name(&raw_type.value);
+    let code = raw_type.code.or_else(|| match raw_type.field.as_str() {
+        "antplus_device_type" => raw_name.as_deref().and_then(reverse_fit_enum::<AntplusDeviceType>),
+        "ble_device_type" => raw_name.as_deref().and_then(reverse_fit_enum::<BleDeviceType>),
+        "local_device_type" => raw_name.as_deref().and_then(reverse_fit_enum::<LocalDeviceType>),
+        _ => numeric_code(&raw_type.value),
+    });
+    let name = raw_name.or_else(|| match raw_type.field.as_str() {
+        "antplus_device_type" => code.and_then(enum_name_from_code::<AntplusDeviceType>),
+        "ble_device_type" => code.and_then(enum_name_from_code::<BleDeviceType>),
+        "local_device_type" => code.and_then(enum_name_from_code::<LocalDeviceType>),
+        _ => None,
+    });
+    let label = device_type_label(name.as_deref());
+    CodeNameLabel { code, name, label }
+}
+
+fn device_index_json(value: Option<&str>, code: Option<i64>) -> JsonValue {
+    if let Some(value) = value.and_then(clean_name) {
+        JsonValue::String(value)
+    } else if let Some(code) = code {
+        JsonValue::from(code)
+    } else {
+        JsonValue::Null
+    }
+}
+
+fn is_creator_index(value: Option<&str>, code: Option<i64>) -> bool {
+    value
+        .map(|v| v.eq_ignore_ascii_case("creator"))
+        .unwrap_or(false)
+        || code == Some(0)
+}
+
+fn role_for(raw: &RawDeviceInfo, source_type: &CodeNameLabel) -> String {
+    if is_creator_index(raw.device_index_value.as_deref(), raw.device_index_code) {
+        return "primary".to_string();
+    }
+
+    match source_type.name.as_deref() {
+        Some("ant" | "antplus" | "bluetooth" | "bluetooth_low_energy") => "accessory",
+        Some("local") => "internal",
+        _ => "unknown",
+    }
+    .to_string()
+}
+
+fn device_identity_key(
+    raw: &RawDeviceInfo,
+    source_type: &CodeNameLabel,
+    manufacturer: &CodeNameLabel,
+    product: &ProductMetadata,
+    role: &str,
+) -> String {
+    if let Some(serial) = raw.serial_number {
+        return format!(
+            "serial:{role}:{}:{}:{}:{}:{}",
+            source_type.name.as_deref().unwrap_or(""),
+            manufacturer.name.as_deref().unwrap_or(""),
+            product.field.as_deref().unwrap_or(""),
+            product.code.map(|v| v.to_string()).or_else(|| product.name.clone()).unwrap_or_default(),
+            serial
+        );
+    }
+
+    let ant_number = raw.ant_device_number.map(|v| v.to_string()).unwrap_or_default();
+    let ant_tx = raw.ant_transmission_type.map(|v| v.to_string()).unwrap_or_default();
+    if !ant_number.is_empty() || !ant_tx.is_empty() {
+        return format!(
+            "ant:{role}:{}:{}:{}:{}:{}:{}",
+            source_type.name.as_deref().unwrap_or(""),
+            manufacturer.name.as_deref().unwrap_or(""),
+            product.field.as_deref().unwrap_or(""),
+            product.code.map(|v| v.to_string()).or_else(|| product.name.clone()).unwrap_or_default(),
+            ant_number,
+            ant_tx
+        );
+    }
+
+    format!(
+        "index:{role}:{}:{}:{}:{}",
+        source_type.name.as_deref().unwrap_or(""),
+        manufacturer.name.as_deref().unwrap_or(""),
+        product.code.map(|v| v.to_string()).or_else(|| product.name.clone()).unwrap_or_default(),
+        raw.device_index_value
+            .clone()
+            .or_else(|| raw.device_index_code.map(|v| v.to_string()))
+            .unwrap_or_default()
+    )
+}
+
+fn merge_latest_string(target: &mut Option<String>, value: &Option<String>) {
+    if value.as_deref().map(|s| !s.trim().is_empty()).unwrap_or(false) {
+        *target = value.clone();
+    }
+}
+
+fn merge_latest_i64(target: &mut Option<i64>, value: Option<i64>) {
+    if value.is_some() {
+        *target = value;
+    }
+}
+
+fn merge_latest_f64(target: &mut Option<f64>, value: Option<f64>) {
+    if value.is_some() {
+        *target = value;
+    }
+}
+
+#[derive(Debug)]
+struct DeviceAccumulator {
+    device: DeviceMetadata,
+    index_keys: BTreeSet<String>,
+    type_keys: BTreeSet<String>,
+    first_seen_ms: Option<i64>,
+    last_seen_ms: Option<i64>,
+}
+
+impl DeviceAccumulator {
+    fn new(raw: &RawDeviceInfo) -> Self {
+        let source_type = resolve_source_type(raw.source_type_value.as_deref(), raw.source_type_code);
+        let manufacturer = resolve_manufacturer(raw.manufacturer_value.as_deref());
+        let product = resolve_product(raw.product_field.as_deref(), raw.product_value.as_deref(), &manufacturer);
+        let role = role_for(raw, &source_type);
+        let mut device = DeviceMetadata {
+            role,
+            device_indices: Vec::new(),
+            source_type,
+            device_types: Vec::new(),
+            manufacturer,
+            product,
+            serial_number: raw.serial_number,
+            software_version: raw.software_version.clone(),
+            hardware_version: raw.hardware_version,
+            battery_status: raw.battery_status.clone(),
+            battery_level: raw.battery_level,
+            battery_voltage: raw.battery_voltage,
+            identifiers: DeviceIdentifiers {
+                ant_device_number: raw.ant_device_number,
+                ant_transmission_type: raw.ant_transmission_type,
+                ant_network: resolve_ant_network(raw.ant_network_value.as_deref(), raw.ant_network_code),
+                descriptor: raw.descriptor.clone(),
+            },
+            first_seen_utc: raw.timestamp_ms.and_then(utc_from_millis),
+            last_seen_utc: raw.timestamp_ms.and_then(utc_from_millis),
+        };
+
+        let mut acc = Self {
+            device,
+            index_keys: BTreeSet::new(),
+            type_keys: BTreeSet::new(),
+            first_seen_ms: raw.timestamp_ms,
+            last_seen_ms: raw.timestamp_ms,
+        };
+        acc.merge(raw);
+        acc
+    }
+
+    fn merge(&mut self, raw: &RawDeviceInfo) {
+        let index = device_index_json(raw.device_index_value.as_deref(), raw.device_index_code);
+        let index_key = index.to_string();
+        if index != JsonValue::Null && self.index_keys.insert(index_key) {
+            self.device.device_indices.push(index);
+        }
+
+        for raw_type in &raw.device_types {
+            let device_type = resolve_device_type(raw_type);
+            let type_key = format!(
+                "{}:{}",
+                device_type.code.map(|v| v.to_string()).unwrap_or_default(),
+                device_type.name.as_deref().unwrap_or("")
+            );
+            if self.type_keys.insert(type_key) {
+                self.device.device_types.push(device_type);
+            }
+        }
+
+        if let Some(timestamp_ms) = raw.timestamp_ms {
+            self.first_seen_ms = Some(self.first_seen_ms.map_or(timestamp_ms, |v| v.min(timestamp_ms)));
+            self.last_seen_ms = Some(self.last_seen_ms.map_or(timestamp_ms, |v| v.max(timestamp_ms)));
+            self.device.first_seen_utc = self.first_seen_ms.and_then(utc_from_millis);
+            self.device.last_seen_utc = self.last_seen_ms.and_then(utc_from_millis);
+        }
+
+        merge_latest_string(&mut self.device.software_version, &raw.software_version);
+        merge_latest_i64(&mut self.device.hardware_version, raw.hardware_version);
+        merge_latest_string(&mut self.device.battery_status, &raw.battery_status);
+        merge_latest_f64(&mut self.device.battery_level, raw.battery_level);
+        merge_latest_f64(&mut self.device.battery_voltage, raw.battery_voltage);
+        merge_latest_i64(&mut self.device.identifiers.ant_device_number, raw.ant_device_number);
+        merge_latest_i64(
+            &mut self.device.identifiers.ant_transmission_type,
+            raw.ant_transmission_type,
+        );
+        if let Some(ant_network) = resolve_ant_network(raw.ant_network_value.as_deref(), raw.ant_network_code) {
+            self.device.identifiers.ant_network = Some(ant_network);
+        }
+        merge_latest_string(&mut self.device.identifiers.descriptor, &raw.descriptor);
+    }
+}
+
+fn role_order(role: &str) -> usize {
+    match role {
+        "primary" => 0,
+        "accessory" => 1,
+        "internal" => 2,
+        _ => 3,
+    }
+}
+
+fn type_order(device: &DeviceMetadata) -> usize {
+    let names = device
+        .device_types
+        .iter()
+        .filter_map(|device_type| device_type.name.as_deref())
+        .collect::<Vec<_>>();
+    if names.iter().any(|name| *name == "heart_rate") {
+        0
+    } else if names.iter().any(|name| *name == "bike_power") {
+        1
+    } else if names.iter().any(|name| *name == "bike_cadence") {
+        2
+    } else if names.iter().any(|name| *name == "bike_speed") {
+        3
+    } else if names.iter().any(|name| *name == "bike_speed_cadence") {
+        4
+    } else if names.iter().any(|name| *name == "bike_radar") {
+        5
+    } else if names
+        .iter()
+        .any(|name| *name == "bike_light_main" || *name == "bike_light_shared")
+    {
+        6
+    } else if names.iter().any(|name| *name == "shifting") {
+        7
+    } else if names.iter().any(|name| *name == "temperature") {
+        8
+    } else {
+        9
+    }
+}
+
+fn display_sort_label(device: &DeviceMetadata) -> String {
+    [
+        device.manufacturer.label.clone(),
+        device.product.label.clone(),
+        device
+            .device_types
+            .first()
+            .and_then(|device_type| device_type.label.clone()),
+        device.serial_number.map(|serial| serial.to_string()),
+    ]
+    .into_iter()
+    .flatten()
+    .collect::<Vec<_>>()
+    .join(" ")
+    .to_lowercase()
+}
+
+pub fn build_devices(raw_records: &[RawDeviceInfo]) -> Vec<DeviceMetadata> {
+    let mut devices: BTreeMap<String, DeviceAccumulator> = BTreeMap::new();
+    for raw in raw_records {
+        let source_type = resolve_source_type(raw.source_type_value.as_deref(), raw.source_type_code);
+        let manufacturer = resolve_manufacturer(raw.manufacturer_value.as_deref());
+        let product = resolve_product(raw.product_field.as_deref(), raw.product_value.as_deref(), &manufacturer);
+        let role = role_for(raw, &source_type);
+        let key = device_identity_key(raw, &source_type, &manufacturer, &product, &role);
+        devices
+            .entry(key)
+            .and_modify(|acc| acc.merge(raw))
+            .or_insert_with(|| DeviceAccumulator::new(raw));
+    }
+
+    let mut devices = devices
+        .into_values()
+        .map(|acc| acc.device)
+        .collect::<Vec<_>>();
+    devices.sort_by(|a, b| {
+        role_order(&a.role)
+            .cmp(&role_order(&b.role))
+            .then_with(|| type_order(a).cmp(&type_order(b)))
+            .then_with(|| display_sort_label(a).cmp(&display_sort_label(b)))
+    });
+    devices
+}
+
+pub fn decoded_file_id(raw: &RawFileId) -> DecodedFileIdMetadata {
+    let manufacturer = resolve_manufacturer(raw.manufacturer_value.as_deref());
+    let product = resolve_product(raw.product_field.as_deref(), raw.product_value.as_deref(), &manufacturer);
+    DecodedFileIdMetadata {
+        manufacturer,
+        product,
+        serial_number: raw.serial_number,
+        time_created_utc: raw.time_created_ms.and_then(utc_from_millis),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reverse_mapping_preserves_valid_zero_codes() {
+        assert_eq!(reverse_fit_enum::<LocalDeviceType>("gps"), Some(0));
+    }
+
+    #[test]
+    fn reverse_mapping_rejects_unknown_zero_fallbacks() {
+        assert_eq!(reverse_fit_enum::<GarminProduct>("not_a_product"), None);
+    }
+
+    #[test]
+    fn garmin_hrm_200_overlay_fills_sdk_gap() {
+        let manufacturer = resolve_manufacturer(Some("garmin"));
+        let product = resolve_product(Some("garmin_product"), Some("4606"), &manufacturer);
+        assert_eq!(product.code, Some(4606));
+        assert_eq!(product.name.as_deref(), Some("hrm_200"));
+        assert_eq!(product.label.as_deref(), Some("HRM 200"));
+        assert_eq!(product.lookup_source, "app_overlay");
+    }
+
+    #[test]
+    fn same_serial_radar_and_light_records_merge_types() {
+        let base = RawDeviceInfo {
+            source_type_value: Some("antplus".to_string()),
+            source_type_code: Some(1),
+            manufacturer_value: Some("garmin".to_string()),
+            product_field: Some("garmin_product".to_string()),
+            product_value: Some("3592".to_string()),
+            serial_number: Some(123),
+            ..Default::default()
+        };
+        let mut light = base.clone();
+        light.device_index_value = Some("5".to_string());
+        light.device_index_code = Some(5);
+        light.device_types.push(RawDeviceType {
+            field: "antplus_device_type".to_string(),
+            value: "bike_light_main".to_string(),
+            code: Some(35),
+        });
+        let mut radar = base;
+        radar.device_index_value = Some("6".to_string());
+        radar.device_index_code = Some(6);
+        radar.device_types.push(RawDeviceType {
+            field: "antplus_device_type".to_string(),
+            value: "bike_radar".to_string(),
+            code: Some(40),
+        });
+
+        let devices = build_devices(&[light, radar]);
+        assert_eq!(devices.len(), 1);
+        assert_eq!(devices[0].device_indices, vec![JsonValue::from(5), JsonValue::from(6)]);
+        let names = devices[0]
+            .device_types
+            .iter()
+            .map(|device_type| device_type.name.as_deref())
+            .collect::<Vec<_>>();
+        assert!(names.contains(&Some("bike_light_main")));
+        assert!(names.contains(&Some("bike_radar")));
+    }
+}

--- a/src-tauri/src/device_metadata.rs
+++ b/src-tauri/src/device_metadata.rs
@@ -234,13 +234,65 @@ fn manufacturer_label(name: Option<&str>) -> Option<String> {
     })
 }
 
+fn forerunner_label(name: &str) -> Option<String> {
+    let suffix = name.strip_prefix("fr")?;
+    let mut parts = suffix.split('_');
+    let model_part = parts.next()?;
+    let (model, has_music_suffix) = model_part
+        .strip_suffix('m')
+        .filter(|base| !base.is_empty() && base.chars().all(|c| c.is_ascii_digit()))
+        .map(|base| (base, true))
+        .unwrap_or((model_part, false));
+
+    if model.is_empty() || !model.chars().all(|c| c.is_ascii_digit()) {
+        return None;
+    }
+
+    let mut model_suffix = String::new();
+    let mut descriptors: Vec<String> = Vec::new();
+    if has_music_suffix {
+        descriptors.push("Music".to_string());
+    }
+
+    for part in parts {
+        let descriptor = match part {
+            "small" | "s" => {
+                model_suffix.push('S');
+                None
+            }
+            "large" => None,
+            "m" | "music" => Some("Music".to_string()),
+            "lte" => Some("LTE".to_string()),
+            "asia" => Some("Asia".to_string()),
+            "apac" => Some("APAC".to_string()),
+            "japan" => Some("Japan".to_string()),
+            "korea" => Some("Korea".to_string()),
+            "china" => Some("China".to_string()),
+            "sea" => Some("SEA".to_string()),
+            other => Some(humanize_identifier(other)),
+        };
+        if let Some(descriptor) = descriptor {
+            if !descriptors.contains(&descriptor) {
+                descriptors.push(descriptor);
+            }
+        }
+    }
+
+    let suffix = if descriptors.is_empty() {
+        String::new()
+    } else {
+        format!(" {}", descriptors.join(" "))
+    };
+    Some(format!("Forerunner {model}{model_suffix}{suffix}"))
+}
+
 fn product_label(name: Option<&str>) -> Option<String> {
     name.map(|value| match value {
         "edge_1040" => "Edge 1040".to_string(),
         "hrm_200" => "HRM 200".to_string(),
         "assioma_duo" => "Assioma Duo".to_string(),
         "assioma_uno" => "Assioma Uno".to_string(),
-        other => humanize_identifier(other),
+        other => forerunner_label(other).unwrap_or_else(|| humanize_identifier(other)),
     })
 }
 
@@ -504,7 +556,7 @@ impl DeviceAccumulator {
         let manufacturer = resolve_manufacturer(raw.manufacturer_value.as_deref());
         let product = resolve_product(raw.product_field.as_deref(), raw.product_value.as_deref(), &manufacturer);
         let role = role_for(raw, &source_type);
-        let mut device = DeviceMetadata {
+        let device = DeviceMetadata {
             role,
             device_indices: Vec::new(),
             source_type,
@@ -689,6 +741,15 @@ mod tests {
     #[test]
     fn reverse_mapping_rejects_unknown_zero_fallbacks() {
         assert_eq!(reverse_fit_enum::<GarminProduct>("not_a_product"), None);
+    }
+
+    #[test]
+    fn garmin_forerunner_labels_expand_fr_prefix() {
+        assert_eq!(product_label(Some("fr255")).as_deref(), Some("Forerunner 255"));
+        assert_eq!(
+            product_label(Some("fr255_small_music")).as_deref(),
+            Some("Forerunner 255S Music")
+        );
     }
 
     #[test]

--- a/src-tauri/src/device_metadata.rs
+++ b/src-tauri/src/device_metadata.rs
@@ -341,19 +341,6 @@ pub fn resolve_manufacturer(raw: Option<&str>) -> CodeNameLabel {
     CodeNameLabel { code, name, label }
 }
 
-fn overlay_product(
-    manufacturer_name: Option<&str>,
-    field: Option<&str>,
-    code: Option<i64>,
-) -> Option<(&'static str, &'static str)> {
-    match (manufacturer_name, field, code) {
-        (Some("garmin"), Some("garmin_product" | "product"), Some(4606)) => {
-            Some(("hrm_200", "HRM 200"))
-        }
-        _ => None,
-    }
-}
-
 pub fn resolve_product(
     field: Option<&str>,
     raw: Option<&str>,
@@ -375,16 +362,6 @@ pub fn resolve_product(
             }
             _ => None,
         });
-
-    if let Some((name, label)) = overlay_product(manufacturer.name.as_deref(), field_name, code) {
-        return ProductMetadata {
-            field,
-            code,
-            name: Some(name.to_string()),
-            label: Some(label.to_string()),
-            lookup_source: "app_overlay".to_string(),
-        };
-    }
 
     let name = raw_name.or_else(|| match field_name {
         Some("garmin_product") => code.and_then(enum_name_from_code::<GarminProduct>),
@@ -464,6 +441,34 @@ fn is_creator_index(value: Option<&str>, code: Option<i64>) -> bool {
         .map(|v| v.eq_ignore_ascii_case("creator"))
         .unwrap_or(false)
         || code == Some(0)
+}
+
+fn device_index_identity(raw: &RawDeviceInfo) -> Option<String> {
+    raw.device_index_code
+        .map(|code| code.to_string())
+        .or_else(|| raw.device_index_value.as_deref().and_then(clean_name))
+}
+
+fn product_identity(product: &ProductMetadata) -> Option<String> {
+    product
+        .code
+        .map(|code| code.to_string())
+        .or_else(|| product.name.clone())
+}
+
+fn serial_index_signature(
+    raw: &RawDeviceInfo,
+    source_type: &CodeNameLabel,
+    product: &ProductMetadata,
+    role: &str,
+) -> Option<String> {
+    Some(format!(
+        "{}:{}:{}:{}",
+        role,
+        source_type.name.as_deref().unwrap_or(""),
+        product_identity(product)?,
+        device_index_identity(raw)?
+    ))
 }
 
 fn role_for(raw: &RawDeviceInfo, source_type: &CodeNameLabel) -> String {
@@ -692,13 +697,47 @@ fn display_sort_label(device: &DeviceMetadata) -> String {
 }
 
 pub fn build_devices(raw_records: &[RawDeviceInfo]) -> Vec<DeviceMetadata> {
-    let mut devices: BTreeMap<String, DeviceAccumulator> = BTreeMap::new();
+    let mut serial_keys_by_index: BTreeMap<String, Option<String>> = BTreeMap::new();
     for raw in raw_records {
+        if raw.serial_number.is_none() {
+            continue;
+        }
+
         let source_type = resolve_source_type(raw.source_type_value.as_deref(), raw.source_type_code);
         let manufacturer = resolve_manufacturer(raw.manufacturer_value.as_deref());
         let product = resolve_product(raw.product_field.as_deref(), raw.product_value.as_deref(), &manufacturer);
         let role = role_for(raw, &source_type);
-        let key = device_identity_key(raw, &source_type, &manufacturer, &product, &role);
+        if let Some(signature) = serial_index_signature(raw, &source_type, &product, &role) {
+            let key = device_identity_key(raw, &source_type, &manufacturer, &product, &role);
+            serial_keys_by_index
+                .entry(signature)
+                .and_modify(|existing| {
+                    if existing.as_ref() != Some(&key) {
+                        *existing = None;
+                    }
+                })
+                .or_insert_with(|| Some(key));
+        }
+    }
+
+    let mut devices: BTreeMap<String, DeviceAccumulator> = BTreeMap::new();
+    for raw in raw_records
+        .iter()
+        .filter(|raw| raw.serial_number.is_some())
+        .chain(raw_records.iter().filter(|raw| raw.serial_number.is_none()))
+    {
+        let source_type = resolve_source_type(raw.source_type_value.as_deref(), raw.source_type_code);
+        let manufacturer = resolve_manufacturer(raw.manufacturer_value.as_deref());
+        let product = resolve_product(raw.product_field.as_deref(), raw.product_value.as_deref(), &manufacturer);
+        let role = role_for(raw, &source_type);
+        let mut key = device_identity_key(raw, &source_type, &manufacturer, &product, &role);
+        if raw.serial_number.is_none() {
+            if let Some(signature) = serial_index_signature(raw, &source_type, &product, &role) {
+                if let Some(Some(serial_key)) = serial_keys_by_index.get(&signature) {
+                    key = serial_key.clone();
+                }
+            }
+        }
         devices
             .entry(key)
             .and_modify(|acc| acc.merge(raw))
@@ -753,13 +792,13 @@ mod tests {
     }
 
     #[test]
-    fn garmin_hrm_200_overlay_fills_sdk_gap() {
+    fn unresolved_garmin_hrm_200_code_stays_raw_for_display_layer() {
         let manufacturer = resolve_manufacturer(Some("garmin"));
         let product = resolve_product(Some("garmin_product"), Some("4606"), &manufacturer);
         assert_eq!(product.code, Some(4606));
-        assert_eq!(product.name.as_deref(), Some("hrm_200"));
-        assert_eq!(product.label.as_deref(), Some("HRM 200"));
-        assert_eq!(product.lookup_source, "app_overlay");
+        assert_eq!(product.name, None);
+        assert_eq!(product.label, None);
+        assert_eq!(product.lookup_source, "raw");
     }
 
     #[test]
@@ -800,5 +839,52 @@ mod tests {
             .collect::<Vec<_>>();
         assert!(names.contains(&Some("bike_light_main")));
         assert!(names.contains(&Some("bike_radar")));
+    }
+
+    #[test]
+    fn missing_serial_records_merge_into_serial_device_for_same_index_and_product() {
+        let serial_base = RawDeviceInfo {
+            source_type_value: Some("antplus".to_string()),
+            source_type_code: Some(1),
+            manufacturer_value: Some("garmin".to_string()),
+            product_field: Some("garmin_product".to_string()),
+            product_value: Some("3592".to_string()),
+            serial_number: Some(123),
+            ..Default::default()
+        };
+
+        let mut light = serial_base.clone();
+        light.device_index_value = Some("5".to_string());
+        light.device_index_code = Some(5);
+        light.device_types.push(RawDeviceType {
+            field: "antplus_device_type".to_string(),
+            value: "bike_light_main".to_string(),
+            code: Some(35),
+        });
+
+        let mut light_without_serial = light.clone();
+        light_without_serial.manufacturer_value = None;
+        light_without_serial.product_field = Some("product".to_string());
+        light_without_serial.serial_number = None;
+        light_without_serial.battery_level = Some(74.0);
+
+        let mut radar = serial_base;
+        radar.device_index_value = Some("6".to_string());
+        radar.device_index_code = Some(6);
+        radar.device_types.push(RawDeviceType {
+            field: "antplus_device_type".to_string(),
+            value: "bike_radar".to_string(),
+            code: Some(40),
+        });
+
+        let mut radar_without_serial = radar.clone();
+        radar_without_serial.serial_number = None;
+        radar_without_serial.battery_level = Some(73.0);
+
+        let devices = build_devices(&[light_without_serial, radar_without_serial, light, radar]);
+        assert_eq!(devices.len(), 1);
+        assert_eq!(devices[0].serial_number, Some(123));
+        assert_eq!(devices[0].device_indices, vec![JsonValue::from(5), JsonValue::from(6)]);
+        assert_eq!(devices[0].battery_level, Some(73.0));
     }
 }

--- a/src-tauri/src/device_metadata.rs
+++ b/src-tauri/src/device_metadata.rs
@@ -768,6 +768,30 @@ pub fn decoded_file_id(raw: &RawFileId) -> DecodedFileIdMetadata {
     }
 }
 
+pub fn decoded_file_id_display_name(decoded: &DecodedFileIdMetadata) -> Option<String> {
+    let manufacturer = decoded
+        .manufacturer
+        .label
+        .as_deref()
+        .or(decoded.manufacturer.name.as_deref())
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+    let product = decoded
+        .product
+        .label
+        .as_deref()
+        .or(decoded.product.name.as_deref())
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+
+    match (manufacturer, product) {
+        (Some(manufacturer), Some(product)) => Some(format!("{manufacturer} {product}")),
+        (Some(manufacturer), None) => Some(manufacturer.to_string()),
+        (None, Some(product)) => Some(product.to_string()),
+        (None, None) => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -788,6 +812,21 @@ mod tests {
         assert_eq!(
             product_label(Some("fr255_small_music")).as_deref(),
             Some("Forerunner 255S Music")
+        );
+    }
+
+    #[test]
+    fn decoded_file_id_display_name_uses_resolved_labels() {
+        let decoded = decoded_file_id(&RawFileId {
+            manufacturer_value: Some("garmin".to_string()),
+            product_field: Some("garmin_product".to_string()),
+            product_value: Some("fr255".to_string()),
+            ..Default::default()
+        });
+
+        assert_eq!(
+            decoded_file_id_display_name(&decoded).as_deref(),
+            Some("Garmin Forerunner 255")
         );
     }
 

--- a/src-tauri/src/fit_parser.rs
+++ b/src-tauri/src/fit_parser.rs
@@ -4,7 +4,10 @@ use anyhow::{anyhow, Context, Result};
 use fitparser::{profile::MesgNum, Value};
 use sha2::{Digest, Sha256};
 
-use crate::device_metadata::{build_devices, decoded_file_id, RawDeviceInfo, RawDeviceType, RawFileId};
+use crate::device_metadata::{
+    build_devices, decoded_file_id, decoded_file_id_display_name, RawDeviceInfo, RawDeviceType,
+    RawFileId,
+};
 use crate::models::{ParsedActivity, RecordPoint};
 
 const NON_ACTIVITY_FIT_MARKER: &str = "non-activity-fit:";
@@ -699,9 +702,13 @@ fn parse_fit_bytes(file_name: &str, bytes: &[u8]) -> Result<ParsedActivity> {
         file_id_product,
     );
 
+    let decoded_file_id_metadata = decoded_file_id(&raw_file_id);
+    let decoded_file_id_name = decoded_file_id_display_name(&decoded_file_id_metadata);
+
     if device.is_empty() {
         device = device_info_creator_name
             .clone()
+            .or(decoded_file_id_name)
             .or(file_id_combined_name.clone())
             .or(device_info_fallback_name.clone())
             .unwrap_or_default();
@@ -710,7 +717,6 @@ fn parse_fit_bytes(file_name: &str, bytes: &[u8]) -> Result<ParsedActivity> {
     let resolved_serial_number = file_id_serial_number
         .or(device_info_creator_serial)
         .or(device_info_fallback_serial);
-    let decoded_file_id_metadata = decoded_file_id(&raw_file_id);
     let device_entries = build_devices(&raw_device_info_records);
 
     let metadata_json = serde_json::json!({

--- a/src-tauri/src/fit_parser.rs
+++ b/src-tauri/src/fit_parser.rs
@@ -4,6 +4,7 @@ use anyhow::{anyhow, Context, Result};
 use fitparser::{profile::MesgNum, Value};
 use sha2::{Digest, Sha256};
 
+use crate::device_metadata::{build_devices, decoded_file_id, RawDeviceInfo, RawDeviceType, RawFileId};
 use crate::models::{ParsedActivity, RecordPoint};
 
 const NON_ACTIVITY_FIT_MARKER: &str = "non-activity-fit:";
@@ -111,6 +112,10 @@ fn value_timestamp_ms(v: &Value) -> Option<i64> {
         Value::String(s) => parse_timestamp_ms(s),
         _ => None,
     }
+}
+
+fn format_fit_version(v: &Value) -> Option<String> {
+    value_f64(v).map(|value| format!("{value:.2}"))
 }
 
 fn strip_known_extension(file_name: &str) -> String {
@@ -293,6 +298,8 @@ fn parse_fit_bytes(file_name: &str, bytes: &[u8]) -> Result<ParsedActivity> {
     let mut file_id_serial_number: Option<i64> = None;
     let mut file_id_type_name: Option<String> = None;
     let mut file_id_type_code: Option<i64> = None;
+    let mut raw_file_id = RawFileId::default();
+    let mut raw_device_info_records: Vec<RawDeviceInfo> = Vec::new();
     let mut device_info_fallback_name: Option<String> = None;
     let mut device_info_fallback_serial: Option<i64> = None;
     let mut device_info_creator_name: Option<String> = None;
@@ -394,6 +401,7 @@ fn parse_fit_bytes(file_name: &str, bytes: &[u8]) -> Result<ParsedActivity> {
                 }
             }
         } else if rec.kind() == MesgNum::DeviceInfo {
+            let mut raw_device_info = RawDeviceInfo::default();
             let mut candidate_product_name: Option<String> = None;
             let mut candidate_manufacturer: Option<String> = None;
             let mut candidate_product: Option<String> = None;
@@ -402,32 +410,91 @@ fn parse_fit_bytes(file_name: &str, bytes: &[u8]) -> Result<ParsedActivity> {
 
             for field in rec.fields() {
                 match field.name() {
+                    "timestamp" => {
+                        raw_device_info.timestamp_ms = value_timestamp_ms(field.value());
+                    }
                     "device_index" => {
-                        let v = value_string(field.value()).to_lowercase();
-                        if v == "creator" || value_i64(field.value()) == Some(0) {
+                        let v = value_string(field.value());
+                        raw_device_info.device_index_value = Some(v.clone());
+                        raw_device_info.device_index_code = value_i64(field.value());
+                        if v.eq_ignore_ascii_case("creator") || raw_device_info.device_index_code == Some(0) {
                             is_creator = true;
                         }
+                    }
+                    "source_type" => {
+                        raw_device_info.source_type_value = Some(value_string(field.value()));
+                        raw_device_info.source_type_code = value_i64(field.value());
                     }
                     "product_name" => {
                         let value = value_string(field.value());
                         if !value.trim().is_empty() {
+                            raw_device_info.product_name = Some(value.clone());
                             candidate_product_name = Some(value);
                         }
                     }
                     "manufacturer" => {
                         let value = value_string(field.value());
                         if !value.trim().is_empty() {
+                            raw_device_info.manufacturer_value = Some(value.clone());
                             candidate_manufacturer = Some(value);
                         }
                     }
                     "garmin_product" | "product" | "favero_product" => {
                         let value = value_string(field.value());
                         if !value.trim().is_empty() {
+                            raw_device_info.product_field = Some(field.name().to_string());
+                            raw_device_info.product_value = Some(value.clone());
                             candidate_product = Some(value);
                         }
                     }
                     "serial_number" => {
                         candidate_serial = value_i64(field.value()).filter(|v| *v > 0);
+                        raw_device_info.serial_number = candidate_serial;
+                    }
+                    "software_version" => {
+                        raw_device_info.software_version = format_fit_version(field.value());
+                    }
+                    "hardware_version" => {
+                        raw_device_info.hardware_version = value_i64(field.value());
+                    }
+                    "battery_status" => {
+                        let value = value_string(field.value());
+                        if !value.trim().is_empty() {
+                            raw_device_info.battery_status = Some(value);
+                        }
+                    }
+                    "battery_level" => {
+                        raw_device_info.battery_level = value_f64(field.value());
+                    }
+                    "battery_voltage" => {
+                        raw_device_info.battery_voltage = value_f64(field.value());
+                    }
+                    "ant_device_number" => {
+                        raw_device_info.ant_device_number = value_i64(field.value());
+                    }
+                    "ant_transmission_type" => {
+                        raw_device_info.ant_transmission_type = value_i64(field.value());
+                    }
+                    "ant_network" => {
+                        raw_device_info.ant_network_value = Some(value_string(field.value()));
+                        raw_device_info.ant_network_code = value_i64(field.value());
+                    }
+                    "descriptor" => {
+                        let value = value_string(field.value());
+                        if !value.trim().is_empty() {
+                            raw_device_info.descriptor = Some(value);
+                        }
+                    }
+                    "antplus_device_type" | "ble_device_type" | "local_device_type" | "device_type"
+                    | "ant_device_type" => {
+                        let value = value_string(field.value());
+                        if !value.trim().is_empty() {
+                            raw_device_info.device_types.push(RawDeviceType {
+                                field: field.name().to_string(),
+                                value,
+                                code: value_i64(field.value()),
+                            });
+                        }
                     }
                     _ => {}
                 }
@@ -450,6 +517,8 @@ fn parse_fit_bytes(file_name: &str, bytes: &[u8]) -> Result<ParsedActivity> {
                 device_info_creator_name = candidate_name;
                 device_info_creator_serial = candidate_serial;
             }
+
+            raw_device_info_records.push(raw_device_info);
         } else if rec.kind() == MesgNum::FileId {
             for field in rec.fields() {
                 match field.name() {
@@ -461,6 +530,9 @@ fn parse_fit_bytes(file_name: &str, bytes: &[u8]) -> Result<ParsedActivity> {
                         }
                         file_id_type_code = value_i64(field.value());
                     }
+                    "time_created" => {
+                        raw_file_id.time_created_ms = value_timestamp_ms(field.value());
+                    }
                     "product_name" => {
                         let value = value_string(field.value());
                         if !value.is_empty() {
@@ -470,17 +542,21 @@ fn parse_fit_bytes(file_name: &str, bytes: &[u8]) -> Result<ParsedActivity> {
                     "manufacturer" => {
                         let value = value_string(field.value());
                         if !value.trim().is_empty() {
+                            raw_file_id.manufacturer_value = Some(value.clone());
                             file_id_manufacturer = Some(value);
                         }
                     }
                     "garmin_product" | "product" | "favero_product" => {
                         let value = value_string(field.value());
                         if !value.trim().is_empty() {
+                            raw_file_id.product_field = Some(field.name().to_string());
+                            raw_file_id.product_value = Some(value.clone());
                             file_id_product = Some(value);
                         }
                     }
                     "serial_number" => {
                         file_id_serial_number = value_i64(field.value()).filter(|v| *v > 0);
+                        raw_file_id.serial_number = file_id_serial_number;
                     }
                     _ => {}
                 }
@@ -634,6 +710,8 @@ fn parse_fit_bytes(file_name: &str, bytes: &[u8]) -> Result<ParsedActivity> {
     let resolved_serial_number = file_id_serial_number
         .or(device_info_creator_serial)
         .or(device_info_fallback_serial);
+    let decoded_file_id_metadata = decoded_file_id(&raw_file_id);
+    let device_entries = build_devices(&raw_device_info_records);
 
     let metadata_json = serde_json::json!({
         "record_count": points.len(),
@@ -645,10 +723,15 @@ fn parse_fit_bytes(file_name: &str, bytes: &[u8]) -> Result<ParsedActivity> {
             "serial_number": resolved_serial_number
         },
         "device_info": {
+            "schema_version": 1,
+            "source_support": "full",
             "creator_product_name": device_info_creator_name,
             "creator_serial_number": device_info_creator_serial,
             "fallback_product_name": device_info_fallback_name,
-            "fallback_serial_number": device_info_fallback_serial
+            "fallback_serial_number": device_info_fallback_serial,
+            "decoded_file_id": decoded_file_id_metadata,
+            "devices": device_entries,
+            "raw_device_info_record_count": raw_device_info_records.len()
         },
         "activity_metrics": {
             "vo2_max": vo2_max

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,6 +2,7 @@
 
 mod auth;
 mod database;
+mod device_metadata;
 mod fit_parser;
 mod models;
 #[cfg(all(feature = "web", not(feature = "tauri-app")))]

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -30,51 +30,18 @@ import {
   speedLabel,
 } from "../lib/units";
 import { useTranslation } from "../lib/i18n";
+import {
+  formatDeviceLabel,
+  getAccessoryDevices,
+  getPrimaryDeviceLabel,
+  parseActivityMetadata,
+} from "../lib/deviceMetadata";
 
 type Props = { onLogout: () => Promise<void> };
 
 type VersionBadgeStatus = {
   state: "hidden" | "latest" | "update";
   latestVersion: string | null;
-};
-
-type ActivityMetadata = {
-  heart_rate_zone_bounds_bpm?: number[];
-  file_id?: {
-    product_name?: string | null;
-    serial_number?: number | null;
-  };
-  activity_metrics?: {
-    vo2_max?: number | null;
-  };
-  session?: {
-    beginning_body_battery?: number | null;
-    ending_body_battery?: number | null;
-    max_heart_rate?: number | null;
-    avg_heart_rate?: number | null;
-    max_cadence?: number | null;
-    avg_cadence?: number | null;
-    total_elapsed_time_s?: number | null;
-    total_distance_m?: number | null;
-    total_calories?: number | null;
-  };
-  laps?: Array<{
-    start_ts_utc?: string | null;
-    end_ts_utc?: string | null;
-    total_elapsed_time_s?: number | null;
-    total_timer_time_s?: number | null;
-    total_distance_m?: number | null;
-    avg_speed_m_s?: number | null;
-    max_speed_m_s?: number | null;
-    avg_heart_rate?: number | null;
-    max_heart_rate?: number | null;
-    total_ascent_m?: number | null;
-    total_descent_m?: number | null;
-    avg_cadence?: number | null;
-    max_cadence?: number | null;
-    total_calories?: number | null;
-    best_speed_m_s?: number | null;
-  }>;
 };
 
 /* ── Helpers ─────────────────────────────────────────────────────── */
@@ -107,15 +74,7 @@ function shortenFileName(name: string, maxLength = 45): string {
   return `${name.slice(0, maxLength)}...`;
 }
 
-function parseActivityMetadata(raw?: string): ActivityMetadata | null {
-  if (!raw) return null;
-  try {
-    const parsed = JSON.parse(raw) as ActivityMetadata;
-    return parsed && typeof parsed === "object" ? parsed : null;
-  } catch {
-    return null;
-  }
-}
+
 
 function isTauriRuntime(): boolean {
   return isTauri();
@@ -1022,9 +981,13 @@ export function Dashboard({ onLogout }: Props) {
       .filter((ts) => !!ts),
     [selectedMetadata]
   );
-  const deviceBadgeSerial = typeof selectedMetadata?.file_id?.serial_number === "number"
-    ? String(selectedMetadata.file_id.serial_number)
+  const deviceBadgeLabel = selectedActivity
+    ? getPrimaryDeviceLabel(selectedMetadata, selectedActivity)
     : "";
+  const accessoryDevices = useMemo(
+    () => getAccessoryDevices(selectedMetadata),
+    [selectedMetadata]
+  );
   const detailStats = useMemo(() => {
     if (!selectedActivity) return [] as Array<{ key: string; label: string; value: string; secondary?: string; icon: Icon }>;
     const out: Array<{ key: string; label: string; value: string; secondary?: string; icon: Icon }> = [];
@@ -1563,7 +1526,23 @@ export function Dashboard({ onLogout }: Props) {
                   <div className="detail-badges">
                     <span className="badge">{formatDate(selectedActivity.start_ts_utc)}</span>
                     {selectedActivity.sport && <span className="badge sport">{selectedActivity.sport}</span>}
-                    {deviceBadgeSerial && <span className="badge device">SN {deviceBadgeSerial}</span>}
+                    {deviceBadgeLabel && (
+                      <span
+                        className={`badge device${accessoryDevices.length > 0 ? " has-accessories" : ""}`}
+                        tabIndex={accessoryDevices.length > 0 ? 0 : undefined}
+                      >
+                        {deviceBadgeLabel}
+                        {accessoryDevices.length > 0 && (
+                          <span className="device-accessory-popover">
+                            {accessoryDevices.map((device, index) => (
+                              <span key={`${formatDeviceLabel(device)}-${index}`} className="device-accessory-row">
+                                <span>{formatDeviceLabel(device)}</span>
+                              </span>
+                            ))}
+                          </span>
+                        )}
+                      </span>
+                    )}
                     <label className="detail-toggle-badge" title={t("detail.smoothGraphsTooltip")}>
                       <input
                         type="checkbox"

--- a/src/lib/deviceMetadata.ts
+++ b/src/lib/deviceMetadata.ts
@@ -126,6 +126,30 @@ function firstDeviceTypeLabel(device: DeviceMetadata): string | null {
     ?? null;
 }
 
+function hasDeviceType(device: DeviceMetadata, names: string[], codes: number[]): boolean {
+  return (device.device_types ?? []).some((type) => {
+    const name = type.name?.toLowerCase();
+    return (name ? names.includes(name) : false)
+      || (typeof type.code === "number" ? codes.includes(type.code) : false);
+  });
+}
+
+function isExternalSource(device: DeviceMetadata): boolean {
+  return ["ant", "antplus", "bluetooth", "bluetooth_low_energy"].includes(
+    device.source_type?.name?.toLowerCase() ?? ""
+  );
+}
+
+function isGarmin(device: DeviceMetadata): boolean {
+  return device.manufacturer?.name?.toLowerCase() === "garmin" || device.manufacturer?.code === 1;
+}
+
+function displayManufacturerLabel(device: DeviceMetadata): string | null {
+  return device.manufacturer?.label
+    ?? labelFromIdentifier(device.manufacturer?.name)
+    ?? null;
+}
+
 function forerunnerLabel(value?: string | null): string | null {
   const match = value?.match(/^fr(\d+)(m)?(?:_(.*))?$/i);
   if (!match) return null;
@@ -150,7 +174,28 @@ function forerunnerLabel(value?: string | null): string | null {
   return `Forerunner ${model}${modelSuffix}${suffix}`;
 }
 
-function formatProductLabel(product?: ProductMetadata | null): string | null {
+function derivedProductLabel(device: DeviceMetadata): string | null {
+  const product = device.product;
+  if (isGarmin(device)) {
+    if (
+      product?.code === 3592
+      && hasDeviceType(device, ["bike_light_main", "bike_light_shared", "bike_radar"], [35, 40])
+    ) {
+      return "Varia RTL515";
+    }
+
+    if (
+      (product?.code === 4606 || product?.name === "hrm_200")
+      || (
+        product?.code === 255
+        && isExternalSource(device)
+        && hasDeviceType(device, ["heart_rate"], [120])
+      )
+    ) {
+      return "HRM 200";
+    }
+  }
+
   return forerunnerLabel(product?.name)
     ?? product?.label
     ?? labelFromIdentifier(product?.name)
@@ -158,10 +203,8 @@ function formatProductLabel(product?: ProductMetadata | null): string | null {
 }
 
 export function formatDeviceLabel(device: DeviceMetadata): string {
-  const manufacturer = device.manufacturer?.label
-    ?? labelFromIdentifier(device.manufacturer?.name)
-    ?? "";
-  const product = formatProductLabel(device.product)
+  const manufacturer = displayManufacturerLabel(device) ?? "";
+  const product = derivedProductLabel(device)
     ?? firstDeviceTypeLabel(device)
     ?? "";
   return [manufacturer, product].filter(Boolean).join(" ").trim()
@@ -206,6 +249,18 @@ export function getPrimaryDeviceLabel(
   return activity?.device || metadata?.file_id?.product_name || "";
 }
 
+function buildExportDevice(device: DeviceMetadata) {
+  return {
+    ...device,
+    display: {
+      name: formatDeviceLabel(device),
+      manufacturer: displayManufacturerLabel(device),
+      product: derivedProductLabel(device),
+      deviceType: firstDeviceTypeLabel(device),
+    },
+  };
+}
+
 export function buildExportDeviceInfo(metadata: ActivityMetadata | null) {
   const info = metadata?.device_info;
   if (!info) return null;
@@ -215,10 +270,10 @@ export function buildExportDeviceInfo(metadata: ActivityMetadata | null) {
     schemaVersion: info.schema_version ?? null,
     sourceSupport: info.source_support ?? null,
     decodedFileId: info.decoded_file_id ?? null,
-    primary: devices.filter((device) => device.role === "primary"),
-    accessories: getAccessoryDevices(metadata),
-    internal: devices.filter((device) => device.role === "internal"),
-    devices,
+    primary: devices.filter((device) => device.role === "primary").map(buildExportDevice),
+    accessories: getAccessoryDevices(metadata).map(buildExportDevice),
+    internal: devices.filter((device) => device.role === "internal").map(buildExportDevice),
+    devices: devices.map(buildExportDevice),
     rawDeviceInfoRecordCount: info.raw_device_info_record_count ?? null,
   };
 }

--- a/src/lib/deviceMetadata.ts
+++ b/src/lib/deviceMetadata.ts
@@ -174,6 +174,22 @@ function forerunnerLabel(value?: string | null): string | null {
   return `Forerunner ${model}${modelSuffix}${suffix}`;
 }
 
+function isGenericProductLabel(value?: string | null): boolean {
+  return /^product[\s_-]*\d+$/i.test(value?.trim() ?? "");
+}
+
+function profileProductLabel(product?: ProductMetadata | null): string | null {
+  const label = forerunnerLabel(product?.name)
+    ?? product?.label
+    ?? labelFromIdentifier(product?.name);
+
+  return label && !isGenericProductLabel(label) ? label : null;
+}
+
+function rawProductCodeLabel(product?: ProductMetadata | null): string | null {
+  return typeof product?.code === "number" ? `Product ${product.code}` : null;
+}
+
 function derivedProductLabel(device: DeviceMetadata): string | null {
   const product = device.product;
   if (isGarmin(device)) {
@@ -196,19 +212,19 @@ function derivedProductLabel(device: DeviceMetadata): string | null {
     }
   }
 
-  return forerunnerLabel(product?.name)
-    ?? product?.label
-    ?? labelFromIdentifier(product?.name)
-    ?? (typeof product?.code === "number" ? `Product ${product.code}` : null);
+  return profileProductLabel(product);
 }
 
 export function formatDeviceLabel(device: DeviceMetadata): string {
   const manufacturer = displayManufacturerLabel(device) ?? "";
-  const product = derivedProductLabel(device)
-    ?? firstDeviceTypeLabel(device)
-    ?? "";
-  return [manufacturer, product].filter(Boolean).join(" ").trim()
-    || firstDeviceTypeLabel(device)
+  const product = derivedProductLabel(device);
+  const deviceType = firstDeviceTypeLabel(device);
+  const rawProduct = rawProductCodeLabel(device.product);
+  const displayPart = product ?? deviceType ?? rawProduct ?? "";
+
+  return [manufacturer, displayPart].filter(Boolean).join(" ").trim()
+    || deviceType
+    || rawProduct
     || "Device";
 }
 

--- a/src/lib/deviceMetadata.ts
+++ b/src/lib/deviceMetadata.ts
@@ -1,0 +1,194 @@
+import type { Activity } from "../types";
+
+export type CodeNameLabel = {
+  code?: number | null;
+  name?: string | null;
+  label?: string | null;
+};
+
+export type ProductMetadata = {
+  field?: string | null;
+  code?: number | null;
+  name?: string | null;
+  label?: string | null;
+  lookup_source?: string | null;
+};
+
+export type DeviceMetadata = {
+  role?: string | null;
+  device_indices?: Array<string | number | null>;
+  source_type?: CodeNameLabel | null;
+  device_types?: CodeNameLabel[];
+  manufacturer?: CodeNameLabel | null;
+  product?: ProductMetadata | null;
+  serial_number?: number | null;
+  software_version?: string | null;
+  hardware_version?: number | null;
+  battery_status?: string | null;
+  battery_level?: number | null;
+  battery_voltage?: number | null;
+  identifiers?: {
+    ant_device_number?: number | null;
+    ant_transmission_type?: number | null;
+    ant_network?: string | null;
+    descriptor?: string | null;
+  } | null;
+  first_seen_utc?: string | null;
+  last_seen_utc?: string | null;
+};
+
+export type DeviceInfoMetadata = {
+  schema_version?: number | null;
+  source_support?: string | null;
+  creator_product_name?: string | null;
+  creator_serial_number?: number | null;
+  fallback_product_name?: string | null;
+  fallback_serial_number?: number | null;
+  decoded_file_id?: {
+    manufacturer?: CodeNameLabel | null;
+    product?: ProductMetadata | null;
+    serial_number?: number | null;
+    time_created_utc?: string | null;
+  } | null;
+  devices?: DeviceMetadata[];
+  raw_device_info_record_count?: number | null;
+};
+
+export type ActivityMetadata = {
+  heart_rate_zone_bounds_bpm?: number[];
+  file_id?: {
+    product_name?: string | null;
+    serial_number?: number | null;
+  };
+  device_info?: DeviceInfoMetadata | null;
+  activity_metrics?: {
+    vo2_max?: number | null;
+  };
+  session?: {
+    beginning_body_battery?: number | null;
+    ending_body_battery?: number | null;
+    max_heart_rate?: number | null;
+    avg_heart_rate?: number | null;
+    max_cadence?: number | null;
+    avg_cadence?: number | null;
+    total_elapsed_time_s?: number | null;
+    total_distance_m?: number | null;
+    total_calories?: number | null;
+  };
+  laps?: Array<{
+    start_ts_utc?: string | null;
+    end_ts_utc?: string | null;
+    total_elapsed_time_s?: number | null;
+    total_timer_time_s?: number | null;
+    total_distance_m?: number | null;
+    avg_speed_m_s?: number | null;
+    max_speed_m_s?: number | null;
+    avg_heart_rate?: number | null;
+    max_heart_rate?: number | null;
+    total_ascent_m?: number | null;
+    total_descent_m?: number | null;
+    avg_cadence?: number | null;
+    max_cadence?: number | null;
+    total_calories?: number | null;
+    best_speed_m_s?: number | null;
+  }>;
+};
+
+export function parseActivityMetadata(raw?: string): ActivityMetadata | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as ActivityMetadata;
+    return parsed && typeof parsed === "object" ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function labelFromIdentifier(value?: string | null): string | null {
+  if (!value) return null;
+  return value
+    .split("_")
+    .filter(Boolean)
+    .map((part) => {
+      const lower = part.toLowerCase();
+      if (["ant", "gps", "gnss", "hr", "hrm", "ble", "ohr"].includes(lower)) {
+        return lower.toUpperCase();
+      }
+      if (lower === "antplus") return "ANT+";
+      return lower.charAt(0).toUpperCase() + lower.slice(1);
+    })
+    .join(" ");
+}
+
+function firstDeviceTypeLabel(device: DeviceMetadata): string | null {
+  return device.device_types?.find((type) => type.label || type.name)?.label
+    ?? labelFromIdentifier(device.device_types?.find((type) => type.name)?.name)
+    ?? null;
+}
+
+export function formatDeviceLabel(device: DeviceMetadata): string {
+  const manufacturer = device.manufacturer?.label
+    ?? labelFromIdentifier(device.manufacturer?.name)
+    ?? "";
+  const product = device.product?.label
+    ?? labelFromIdentifier(device.product?.name)
+    ?? firstDeviceTypeLabel(device)
+    ?? (typeof device.product?.code === "number" ? `Product ${device.product.code}` : "");
+  return [manufacturer, product].filter(Boolean).join(" ").trim()
+    || firstDeviceTypeLabel(device)
+    || "Device";
+}
+
+function typeOrder(device: DeviceMetadata): number {
+  const names = new Set((device.device_types ?? []).map((type) => type.name));
+  if (names.has("heart_rate")) return 0;
+  if (names.has("bike_power")) return 1;
+  if (names.has("bike_cadence")) return 2;
+  if (names.has("bike_speed")) return 3;
+  if (names.has("bike_speed_cadence")) return 4;
+  if (names.has("bike_radar")) return 5;
+  if (names.has("bike_light_main") || names.has("bike_light_shared")) return 6;
+  if (names.has("shifting")) return 7;
+  if (names.has("temperature")) return 8;
+  return 9;
+}
+
+export function getAccessoryDevices(metadata: ActivityMetadata | null): DeviceMetadata[] {
+  return [...(metadata?.device_info?.devices ?? [])]
+    .filter((device) => device.role === "accessory")
+    .sort((a, b) => {
+      const byType = typeOrder(a) - typeOrder(b);
+      if (byType !== 0) return byType;
+      return formatDeviceLabel(a).localeCompare(formatDeviceLabel(b));
+    });
+}
+
+export function getPrimaryDevice(metadata: ActivityMetadata | null): DeviceMetadata | null {
+  return metadata?.device_info?.devices?.find((device) => device.role === "primary") ?? null;
+}
+
+export function getPrimaryDeviceLabel(
+  metadata: ActivityMetadata | null,
+  activity?: Pick<Activity, "device"> | null
+): string {
+  const primary = getPrimaryDevice(metadata);
+  if (primary) return formatDeviceLabel(primary);
+  return activity?.device || metadata?.file_id?.product_name || "";
+}
+
+export function buildExportDeviceInfo(metadata: ActivityMetadata | null) {
+  const info = metadata?.device_info;
+  if (!info) return null;
+
+  const devices = info.devices ?? [];
+  return {
+    schemaVersion: info.schema_version ?? null,
+    sourceSupport: info.source_support ?? null,
+    decodedFileId: info.decoded_file_id ?? null,
+    primary: devices.filter((device) => device.role === "primary"),
+    accessories: getAccessoryDevices(metadata),
+    internal: devices.filter((device) => device.role === "internal"),
+    devices,
+    rawDeviceInfoRecordCount: info.raw_device_info_record_count ?? null,
+  };
+}

--- a/src/lib/deviceMetadata.ts
+++ b/src/lib/deviceMetadata.ts
@@ -126,14 +126,44 @@ function firstDeviceTypeLabel(device: DeviceMetadata): string | null {
     ?? null;
 }
 
+function forerunnerLabel(value?: string | null): string | null {
+  const match = value?.match(/^fr(\d+)(m)?(?:_(.*))?$/i);
+  if (!match) return null;
+
+  const [, model, musicSuffix, rawRest] = match;
+  let modelSuffix = "";
+  const descriptors = new Set<string>();
+  if (musicSuffix) descriptors.add("Music");
+
+  for (const part of rawRest?.split("_").filter(Boolean) ?? []) {
+    const lower = part.toLowerCase();
+    if (lower === "small" || lower === "s") modelSuffix += "S";
+    else if (lower === "large") continue;
+    else if (lower === "m" || lower === "music") descriptors.add("Music");
+    else if (lower === "lte") descriptors.add("LTE");
+    else if (lower === "apac") descriptors.add("APAC");
+    else if (lower === "sea") descriptors.add("SEA");
+    else descriptors.add(labelFromIdentifier(lower) ?? part);
+  }
+
+  const suffix = descriptors.size > 0 ? ` ${Array.from(descriptors).join(" ")}` : "";
+  return `Forerunner ${model}${modelSuffix}${suffix}`;
+}
+
+function formatProductLabel(product?: ProductMetadata | null): string | null {
+  return forerunnerLabel(product?.name)
+    ?? product?.label
+    ?? labelFromIdentifier(product?.name)
+    ?? (typeof product?.code === "number" ? `Product ${product.code}` : null);
+}
+
 export function formatDeviceLabel(device: DeviceMetadata): string {
   const manufacturer = device.manufacturer?.label
     ?? labelFromIdentifier(device.manufacturer?.name)
     ?? "";
-  const product = device.product?.label
-    ?? labelFromIdentifier(device.product?.name)
+  const product = formatProductLabel(device.product)
     ?? firstDeviceTypeLabel(device)
-    ?? (typeof device.product?.code === "number" ? `Product ${device.product.code}` : "");
+    ?? "";
   return [manufacturer, product].filter(Boolean).join(" ").trim()
     || firstDeviceTypeLabel(device)
     || "Device";

--- a/src/lib/deviceMetadata.ts
+++ b/src/lib/deviceMetadata.ts
@@ -240,13 +240,30 @@ export function getPrimaryDevice(metadata: ActivityMetadata | null): DeviceMetad
   return metadata?.device_info?.devices?.find((device) => device.role === "primary") ?? null;
 }
 
+function decodedFileIdLabel(info?: DeviceInfoMetadata | null): string | null {
+  const decoded = info?.decoded_file_id;
+  if (!decoded) return null;
+
+  const manufacturer = decoded.manufacturer?.label
+    ?? labelFromIdentifier(decoded.manufacturer?.name)
+    ?? null;
+  const product = decoded.product?.label
+    ?? labelFromIdentifier(decoded.product?.name)
+    ?? null;
+  const label = [manufacturer, product].filter(Boolean).join(" ").trim();
+  return label || null;
+}
+
 export function getPrimaryDeviceLabel(
   metadata: ActivityMetadata | null,
   activity?: Pick<Activity, "device"> | null
 ): string {
   const primary = getPrimaryDevice(metadata);
   if (primary) return formatDeviceLabel(primary);
-  return activity?.device || metadata?.file_id?.product_name || "";
+  return decodedFileIdLabel(metadata?.device_info)
+    || activity?.device
+    || metadata?.file_id?.product_name
+    || "";
 }
 
 function buildExportDevice(device: DeviceMetadata) {

--- a/src/lib/exportUtils.ts
+++ b/src/lib/exportUtils.ts
@@ -5,6 +5,7 @@
 
 import type { Activity, RecordPoint } from "../types";
 import { api } from "./api";
+import { buildExportDeviceInfo, parseActivityMetadata } from "./deviceMetadata";
 
 /* ── Helpers ─────────────────────────────────────────────────────── */
 
@@ -93,11 +94,14 @@ export function buildCsv(activity: Activity, records: RecordPoint[]): string {
 /* ── JSON ────────────────────────────────────────────────────────── */
 
 export function buildJson(activity: Activity, records: RecordPoint[]): string {
+  const metadata = parseActivityMetadata(activity.metadata_json);
+
   return JSON.stringify(
     {
       _exportInfo: {
         format: "FIT Dashboard JSON Export",
         exportedAt: new Date().toISOString(),
+        deviceMetadataVersion: metadata?.device_info?.schema_version ?? null,
       },
       activity: {
         id: activity.id,
@@ -110,6 +114,7 @@ export function buildJson(activity: Activity, records: RecordPoint[]): string {
         durationS: activity.duration_s,
         distanceM: activity.distance_m,
       },
+      deviceInfo: buildExportDeviceInfo(metadata),
       records,
     },
     null,

--- a/src/styles.css
+++ b/src/styles.css
@@ -1399,6 +1399,46 @@ button:focus-visible {
   border-color: rgba(245, 158, 11, 0.2);
 }
 
+.badge.device.has-accessories {
+  position: relative;
+  cursor: default;
+  outline: none;
+}
+
+.device-accessory-popover {
+  position: absolute;
+  top: calc(100% + 0.45rem);
+  right: 0;
+  z-index: 20;
+  display: none;
+  min-width: 220px;
+  max-width: min(320px, calc(100vw - 2rem));
+  padding: 0.45rem;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: var(--panel-solid);
+  color: var(--text);
+  box-shadow: var(--shadow-lg);
+  white-space: normal;
+}
+
+.badge.device.has-accessories:hover .device-accessory-popover,
+.badge.device.has-accessories:focus .device-accessory-popover,
+.badge.device.has-accessories:focus-within .device-accessory-popover {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.device-accessory-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.74rem;
+  color: var(--text);
+  line-height: 1.25;
+}
+
 .detail-stats-strip {
   display: flex;
   gap: 1.5rem;


### PR DESCRIPTION
## Summary

Adds structured FIT device metadata so activities can expose the primary recording device and connected accessories separately.

This replaces the compact device badge fallback that could show serial numbers with a human-readable primary device label, while keeping serial numbers available in metadata/export. Raw parsed device facts are preserved, and user-facing labels are derived in the shared UI/export display layer.

Closes #40.

## Changes

- Parse and persist enriched `metadata_json.device_info` for FIT imports.
- Store primary, accessory, and internal device entries with manufacturer, product, source type, device type, serial, software, battery, and identifiers where available.
- Remove serial number fallback from the compact activity device badge.
- Prefer decoded primary device labels such as `Garmin Edge 1040` or `Garmin Forerunner 255`.
- Add shared device display formatting for the UI and JSON export.
- Show accessory details from the primary device badge hover/focus state.
- Add JSON export `deviceInfo` metadata with derived display labels.
- Add display substitutions/fallbacks for observed devices such as:
  - Garmin Varia RTL515
  - Garmin HRM 200
  - Favero Assioma Duo
  - Garmin Forerunner models
- Treat generic `Product #` labels as unresolved and prefer device type labels such as `Magene Speed Sensor` or `Magene Cadence Sensor`.
- Document the device metadata schema, display fallback order, sorting, migration/backfill notes, and known FIT/TCX/GPX limitations.

## Testing

- Ran `npm run build`.
- Verified direct display formatter cases:
  - `Magene Product 3` + `bike_speed` -> `Magene Speed Sensor`
  - `Magene Product 3` + `bike_cadence` -> `Magene Cadence Sensor`
  - no manufacturer + `bike_cadence` -> `Cadence Sensor`
  - raw `Product 3` remains only when no useful device type is available
- Rebuilt local Docker deployment from local `main` for manual testing.

## Notes

Serial numbers are still retained in metadata/export where available, but they are no longer used as compact UI device labels. Raw product codes also remain preserved; friendly product/device names are display-derived and are not written back as authoritative product names.
