### PR TITLE
Hide unavailable activity charts and map panels

### DIFF
--- a/src/components/ActivityChart.tsx
+++ b/src/components/ActivityChart.tsx
@@ -3,6 +3,7 @@ import type { RecordPoint } from "../types";
 import { enableChartWheelPageScroll } from "../lib/chartScroll";
 import { buildHeartRateZones } from "../lib/hrZones";
 import { applyRollingAverageSeries, getDynamicSmoothingWindow } from "../lib/chartSmoothing";
+import { getRecordDataAvailability } from "../lib/recordDataAvailability";
 import { convertDistanceMeters, convertPaceMinPerKm, distanceLabel, paceLabel, type DistanceUnit } from "../lib/units";
 import { useTranslation } from "../lib/i18n";
 
@@ -27,6 +28,7 @@ export function ActivityChart({
   lapTimestampsUtc = [],
   smoothGraphs = true,
 }: Props) {
+  const availability = getRecordDataAvailability(records);
   const t0 = records[0]?.timestamp_ms ?? 0;
   const totalDurationMs = Math.max(0, (records[records.length - 1]?.timestamp_ms ?? t0) - t0);
   const smoothWindow = smoothGraphs ? getDynamicSmoothingWindow(records.length, totalDurationMs, zoomRange) : 1;
@@ -271,8 +273,8 @@ export function ActivityChart({
 
   return (
     <div style={{ display: "grid", gap: 12, minWidth: 0, width: "100%", overflow: "hidden" }}>
-      <ReactECharts option={hrOption} onEvents={onEvents} onChartReady={enableChartWheelPageScroll} notMerge style={{ height: 220, width: "100%", minWidth: 0, overflow: "hidden" }} />
-      <ReactECharts option={paceOption} onEvents={onEvents} onChartReady={enableChartWheelPageScroll} notMerge style={{ height: 220, width: "100%", minWidth: 0, overflow: "hidden" }} />
+      {availability.hasHeartRate && <ReactECharts option={hrOption} onEvents={onEvents} onChartReady={enableChartWheelPageScroll} notMerge style={{ height: 220, width: "100%", minWidth: 0, overflow: "hidden" }} />}
+      {availability.hasPace && <ReactECharts option={paceOption} onEvents={onEvents} onChartReady={enableChartWheelPageScroll} notMerge style={{ height: 220, width: "100%", minWidth: 0, overflow: "hidden" }} />}
     </div>
   );
 }

--- a/src/components/ActivityInsights.tsx
+++ b/src/components/ActivityInsights.tsx
@@ -3,6 +3,7 @@ import type { RecordPoint } from "../types";
 import { enableChartWheelPageScroll } from "../lib/chartScroll";
 import { buildHeartRateZones, resolveHeartRateZoneIndex } from "../lib/hrZones";
 import { applyRollingAverageSeries, getDynamicSmoothingWindow } from "../lib/chartSmoothing";
+import { getRecordDataAvailability } from "../lib/recordDataAvailability";
 import {
   convertElevationMeters,
   convertSpeedMps,
@@ -58,9 +59,10 @@ export function ActivityInsights({
   lapTimestampsUtc = [],
   smoothGraphs = true,
 }: Props) {
-    const hrZones = buildHeartRateZones(heartRateZoneBoundsBpm);
+  const hrZones = buildHeartRateZones(heartRateZoneBoundsBpm);
   const isDark = theme === "dark";
   const { t: tr } = useTranslation();
+  const availability = getRecordDataAvailability(records);
   const axisColor = isDark ? "#8899b8" : "#64748b";
   const gridLine = isDark ? "rgba(100, 140, 220, 0.08)" : "rgba(0, 0, 0, 0.06)";
   const tooltipBg = isDark ? "rgba(14, 22, 45, 0.95)" : "rgba(255, 255, 255, 0.95)";
@@ -120,9 +122,13 @@ export function ActivityInsights({
   const cadenceLineDataSmoothed = smoothGraphs ? applyRollingAverageSeries(cadenceLineData, 1, smoothWindow) : cadenceLineData;
   const powerLineDataSmoothed = smoothGraphs ? applyRollingAverageSeries(powerLineData, 1, smoothWindow) : powerLineData;
 
-  const hasPowerData = records.some((r) => typeof r.power === "number" && r.power > 0);
-  const hasHeartRateData = records.some((r) => typeof r.heart_rate === "number" && r.heart_rate > 0);
-  const hasElevationData = records.some((r) => typeof r.altitude_m === "number" && Number.isFinite(r.altitude_m));
+  const hasPowerData = availability.hasPower;
+  const hasHeartRateData = availability.hasHeartRate;
+  const hasElevationData = availability.hasElevation;
+  const hasSpeedData = availability.hasSpeed;
+  const hasCadenceData = availability.hasCadence;
+  const hasTemperatureData = availability.hasTemperature;
+  const hasHeatmapData = hasHeartRateData || hasSpeedData || hasCadenceData || hasTemperatureData;
 
   const lapMarkers = lapTimestampsUtc
     .slice(1)
@@ -294,7 +300,7 @@ export function ActivityInsights({
         let html = formatTooltipHeader(rel);
         for (const row of params) {
           if (row.value?.[1] !== null && row.value?.[1] !== undefined) {
-            const unit = row.seriesName === "Cadence" ? " rpm" : " W";
+            const unit = row.seriesName === tr("insights.power") ? " W" : " rpm";
             html += `<div>${row.marker} ${row.seriesName}: <strong>${Number(row.value[1]).toFixed(2)}${unit}</strong></div>`;
           }
         }
@@ -302,7 +308,7 @@ export function ActivityInsights({
       }
     },
     legend: { textStyle: { color: axisColor, fontSize: 12 }, top: 0 },
-    grid: { left: 44, right: hasPowerData ? 44 : 16, top: 44, bottom: 44 },
+    grid: { left: 44, right: hasPowerData && hasCadenceData ? 44 : 16, top: 44, bottom: 44 },
     xAxis: {
       type: "value",
       axisLabel: { color: axisColor, fontSize: 11, formatter: (val: number) => formatRelTime(val) },
@@ -311,12 +317,12 @@ export function ActivityInsights({
     },
     yAxis: [
       {
-        type: "value", name: "rpm",
+        type: "value", name: hasCadenceData ? "rpm" : "W",
         nameTextStyle: { color: axisColor, fontSize: 11 },
         axisLabel: { color: axisColor, fontSize: 11 },
         splitLine: { lineStyle: { color: gridLine } },
       },
-      ...(hasPowerData ? [{
+      ...(hasPowerData && hasCadenceData ? [{
         type: "value", name: "W",
         nameTextStyle: { color: axisColor, fontSize: 11 },
         axisLabel: { color: axisColor, fontSize: 11 },
@@ -333,7 +339,7 @@ export function ActivityInsights({
       },
     ],
     series: [
-      {
+      ...(hasCadenceData ? [{
         name: tr("insights.cadence"), type: "line", smooth: smoothGraphs, showSymbol: false,
         lineStyle: { width: 2, color: "#22d3ee" },
         sampling: smoothGraphs ? "lttb" : undefined,
@@ -345,9 +351,9 @@ export function ActivityInsights({
           label: { color: axisColor, fontSize: 10, formatter: "{b}", position: "insideEndTop" },
           data: lapMarkers,
         } : undefined,
-      },
+      }] : []),
       ...(hasPowerData ? [{
-        name: tr("insights.power"), type: "line", yAxisIndex: 1, smooth: smoothGraphs, showSymbol: false,
+        name: tr("insights.power"), type: "line", yAxisIndex: hasCadenceData ? 1 : 0, smooth: smoothGraphs, showSymbol: false,
         sampling: smoothGraphs ? "lttb" : undefined,
         data: powerLineDataSmoothed,
         lineStyle: { color: "#f97316" },
@@ -464,32 +470,39 @@ export function ActivityInsights({
 
   const totalRelMs = Math.max(0, (records[records.length - 1]?.timestamp_ms ?? t0) - t0);
   const heatBins = Math.max(1, Math.ceil(totalRelMs / 60000));
-  const heatMetrics = [
-    {
+  type HeatMetric = {
+    label: string;
+    unit: string;
+    getter: (d: (typeof timeline)[number]) => number | null;
+    colors: string[];
+  };
+
+  const heatMetrics: HeatMetric[] = [
+    ...(hasHeartRateData ? [{
       label: "HR",
       unit: "bpm",
       getter: (d: (typeof timeline)[number]) => d.heartRate,
       colors: isDark ? ["#2a0b12", "#dc2626", "#fb7185"] : ["#fee2e2", "#f87171", "#dc2626"],
-    },
-    {
+    }] : []),
+    ...(hasSpeedData ? [{
       label: "Speed",
       unit: speedLabel(distanceUnit),
       getter: (d: (typeof timeline)[number]) => d.speedInUnit,
       colors: isDark ? ["#0e2a1e", "#16a34a", "#4ade80"] : ["#dcfce7", "#4ade80", "#15803d"],
-    },
-    {
+    }] : []),
+    ...(hasCadenceData ? [{
       label: "Cadence",
       unit: "rpm",
       getter: (d: (typeof timeline)[number]) => d.cadence,
       colors: isDark ? ["#2f1a05", "#f59e0b", "#facc15"] : ["#fef3c7", "#fbbf24", "#d97706"],
-    },
-    {
+    }] : []),
+    ...(hasTemperatureData ? [{
       label: "Temp",
       unit: "degC",
       getter: (d: (typeof timeline)[number]) => d.temperatureC,
       colors: isDark ? ["#0b1a3a", "#1d4ed8", "#38bdf8"] : ["#dbeafe", "#60a5fa", "#1d4ed8"],
-    },
-  ] as const;
+    }] : []),
+  ];
 
   const heatRowBounds = heatMetrics.map(() => ({ min: Number.POSITIVE_INFINITY, max: Number.NEGATIVE_INFINITY }));
   const rawHeatCells: Array<Array<{ x: number; raw: number | null }>> = heatMetrics.map(() => []);
@@ -527,8 +540,10 @@ export function ActivityInsights({
       });
     });
 
-  const rowTop = [16, 64, 112, 160];
   const rowHeight = 34;
+  const rowGap = 14;
+  const rowTop = heatMetrics.map((_, idx) => 16 + idx * (rowHeight + rowGap));
+  const heatChartHeight = Math.max(120, 48 + heatMetrics.length * (rowHeight + rowGap));
 
   const heatOption = {
     tooltip: {
@@ -600,11 +615,13 @@ export function ActivityInsights({
 
   return (
     <section className="insight-grid">
-      <article className="panel">
-        <h3>{tr("insights.speedTrend")}</h3>
-        <ReactECharts option={timelineOption} onEvents={zoomEvents} onChartReady={enableChartWheelPageScroll} notMerge style={{ height: 280, width: "100%" }} />
-      </article>
-      {hasPowerData && hasHeartRateData && (
+      {hasSpeedData && (
+        <article className="panel">
+          <h3>{tr("insights.speedTrend")}</h3>
+          <ReactECharts option={timelineOption} onEvents={zoomEvents} onChartReady={enableChartWheelPageScroll} notMerge style={{ height: 280, width: "100%" }} />
+        </article>
+      )}
+      {hasHeartRateData && (
         <article className="panel">
           <h3>{tr("insights.heartRateZoneTime")}</h3>
           <ReactECharts option={zoneOption} onChartReady={enableChartWheelPageScroll} notMerge style={{ height: 280, width: "100%" }} />
@@ -616,14 +633,18 @@ export function ActivityInsights({
           <ReactECharts option={hrHistogramOption} onChartReady={enableChartWheelPageScroll} notMerge style={{ height: 280, width: "100%" }} />
         </article>
       )}
-      <article className="panel">
-        <h3>{hasPowerData ? tr("insights.cadenceAndPower") : tr("insights.cadence")}</h3>
-        <ReactECharts option={cadenceOption} onEvents={zoomEvents} onChartReady={enableChartWheelPageScroll} notMerge style={{ height: 280, width: "100%" }} />
-      </article>
-      <article className="panel">
-        <h3>{tr("insights.effortHeatmap")}</h3>
-        <ReactECharts option={heatOption} onChartReady={enableChartWheelPageScroll} notMerge style={{ height: 280, width: "100%" }} />
-      </article>
+      {(hasCadenceData || hasPowerData) && (
+        <article className="panel">
+          <h3>{hasCadenceData && hasPowerData ? tr("insights.cadenceAndPower") : (hasPowerData ? tr("insights.power") : tr("insights.cadence"))}</h3>
+          <ReactECharts option={cadenceOption} onEvents={zoomEvents} onChartReady={enableChartWheelPageScroll} notMerge style={{ height: 280, width: "100%" }} />
+        </article>
+      )}
+      {hasHeatmapData && (
+        <article className="panel">
+          <h3>{tr("insights.effortHeatmap")}</h3>
+          <ReactECharts option={heatOption} onChartReady={enableChartWheelPageScroll} notMerge style={{ height: heatChartHeight, width: "100%" }} />
+        </article>
+      )}
       {hasElevationData && (
         <article className="panel">
           <h3>{tr("insights.elevation")}</h3>

--- a/src/components/ActivityInsights.tsx
+++ b/src/components/ActivityInsights.tsx
@@ -122,6 +122,7 @@ export function ActivityInsights({
 
   const hasPowerData = records.some((r) => typeof r.power === "number" && r.power > 0);
   const hasHeartRateData = records.some((r) => typeof r.heart_rate === "number" && r.heart_rate > 0);
+  const hasElevationData = records.some((r) => typeof r.altitude_m === "number" && Number.isFinite(r.altitude_m));
 
   const lapMarkers = lapTimestampsUtc
     .slice(1)
@@ -623,10 +624,12 @@ export function ActivityInsights({
         <h3>{tr("insights.effortHeatmap")}</h3>
         <ReactECharts option={heatOption} onChartReady={enableChartWheelPageScroll} notMerge style={{ height: 280, width: "100%" }} />
       </article>
-      <article className="panel">
-        <h3>{tr("insights.elevation")}</h3>
-        <ReactECharts option={elevationOption} onEvents={zoomEvents} onChartReady={enableChartWheelPageScroll} notMerge style={{ height: 280, width: "100%" }} />
-      </article>
+      {hasElevationData && (
+        <article className="panel">
+          <h3>{tr("insights.elevation")}</h3>
+          <ReactECharts option={elevationOption} onEvents={zoomEvents} onChartReady={enableChartWheelPageScroll} notMerge style={{ height: 280, width: "100%" }} />
+        </article>
+      )}
       {hasPowerData && hasHeartRateData && (
         <article className="panel">
           <h3>{tr("insights.powerVsHeartRate")}</h3>

--- a/src/components/ActivityMap.tsx
+++ b/src/components/ActivityMap.tsx
@@ -3,6 +3,7 @@ import maplibregl, { type StyleSpecification } from "maplibre-gl";
 import type { RecordPoint } from "../types";
 import type { MapStyle } from "../stores/settingsStore";
 import { useSettingsStore } from "../stores/settingsStore";
+import { getRecordDataAvailability } from "../lib/recordDataAvailability";
 import { convertElevationMeters, convertSpeedKmh, elevationLabel, speedLabel } from "../lib/units";
 import { useTranslation } from "../lib/i18n";
 
@@ -88,7 +89,15 @@ function valueToColor(t: number): string {
 
 function getMetricValues(recs: RecordPoint[], mode: PathColorMode): number[] {
   switch (mode) {
-    case "speed": return recs.map((r) => (r.speed_m_s ?? 0) * 3.6);
+    case "speed": return recs.map((r, i) => {
+      if (typeof r.speed_m_s === "number" && r.speed_m_s > 0) return r.speed_m_s * 3.6;
+      const prev = i > 0 ? recs[i - 1] : undefined;
+      const dtS = prev ? (r.timestamp_ms - prev.timestamp_ms) / 1000 : 0;
+      if (prev && typeof r.distance_m === "number" && typeof prev.distance_m === "number" && dtS > 0) {
+        return Math.max(0, ((r.distance_m - prev.distance_m) / dtS) * 3.6);
+      }
+      return 0;
+    });
     case "heart_rate": return recs.map((r) => r.heart_rate ?? 0);
     case "cadence": return recs.map((r) => r.cadence ?? 0);
     case "altitude": return recs.map((r) => r.altitude_m ?? 0);
@@ -378,6 +387,7 @@ export function ActivityMap({ records, mapStyle, setMapStyle, lapTimestampsUtc =
   const distanceUnit = useSettingsStore((s) => s.distanceUnit);
   const selectedStyle = mapStyle === "default" ? theme : mapStyle;
   const { t } = useTranslation();
+  const availability = useMemo(() => getRecordDataAvailability(records), [records]);
 
   const pathColorLabels: Record<PathColorMode, string> = useMemo(() => ({
     solid: t("activityMap.colorSolid"),
@@ -389,6 +399,18 @@ export function ActivityMap({ records, mapStyle, setMapStyle, lapTimestampsUtc =
     temperature: t("activityMap.colorTemperature"),
     time: t("activityMap.colorTime"),
   }), [t]);
+
+  const pathColorOptions = useMemo(() => PATH_COLOR_VALUES.filter((mode) => {
+    switch (mode) {
+      case "speed": return availability.hasSpeed;
+      case "heart_rate": return availability.hasHeartRate;
+      case "cadence": return availability.hasCadence;
+      case "altitude": return availability.hasElevation;
+      case "power": return availability.hasPower;
+      case "temperature": return availability.hasTemperature;
+      default: return true;
+    }
+  }), [availability]);
 
   const [pathColorMode, setPathColorMode] = useState<PathColorMode>("heart_rate");
   const [terrainEnabled, setTerrainEnabled] = useState(false);
@@ -460,6 +482,11 @@ export function ActivityMap({ records, mapStyle, setMapStyle, lapTimestampsUtc =
   useEffect(() => { gpsRecordsRef.current = gpsRecords; }, [gpsRecords]);
   useEffect(() => { distanceUnitRef.current = distanceUnit; }, [distanceUnit]);
   useEffect(() => { pathColorModeRef.current = pathColorMode; }, [pathColorMode]);
+  useEffect(() => {
+    if (!pathColorOptions.includes(pathColorMode)) {
+      setPathColorMode(pathColorOptions.includes("speed") ? "speed" : "solid");
+    }
+  }, [pathColorMode, pathColorOptions]);
   useEffect(() => { terrainEnabledRef.current = terrainEnabled; }, [terrainEnabled]);
   useEffect(() => {
     telemetryEnabledRef.current = telemetryEnabled;
@@ -932,7 +959,7 @@ export function ActivityMap({ records, mapStyle, setMapStyle, lapTimestampsUtc =
           <div className="map-control">
             <span>{t("activityMap.color")}</span>
             <select value={pathColorMode} onChange={(e) => setPathColorMode(e.target.value as PathColorMode)}>
-              {PATH_COLOR_VALUES.map((val) => (
+              {pathColorOptions.map((val) => (
                 <option key={val} value={val}>{pathColorLabels[val]}</option>
               ))}
             </select>

--- a/src/components/CompareCharts.tsx
+++ b/src/components/CompareCharts.tsx
@@ -3,6 +3,7 @@ import type { Activity, RecordPoint } from "../types";
 import { useEffect, useState } from "react";
 import { api } from "../lib/api";
 import { enableChartWheelPageScroll } from "../lib/chartScroll";
+import { combineRecordDataAvailability, getRecordDataAvailability } from "../lib/recordDataAvailability";
 import { convertElevationMeters, convertSpeedMps, elevationLabel, speedLabel, type DistanceUnit } from "../lib/units";
 import { useTranslation } from "../lib/i18n";
 
@@ -93,6 +94,10 @@ export function CompareCharts({ compareIds, activities, theme, distanceUnit }: P
   const tooltipBorder = isDark ? "rgba(100, 140, 220, 0.2)" : "rgba(0, 0, 0, 0.08)";
   const tooltipText = isDark ? "#e2e8f4" : "#0f172a";
 
+  const combinedAvailability = combineRecordDataAvailability(
+    dataSets.map((ds) => getRecordDataAvailability(ds.records))
+  );
+
   const buildSeries = (key: keyof RecordPoint) => {
     return dataSets.map((ds) => {
       const t0 = ds.records[0]?.timestamp_ms ?? 0;
@@ -102,8 +107,15 @@ export function CompareCharts({ compareIds, activities, theme, distanceUnit }: P
         smooth: true,
         showSymbol: false,
         lineStyle: { width: 2 },
-        data: ds.records.map((r) => {
-          const raw = r[key] ?? null;
+        data: ds.records.map((r, i) => {
+          let raw = r[key] ?? null;
+          if (key === "speed_m_s" && (typeof raw !== "number" || raw <= 0)) {
+            const prev = i > 0 ? ds.records[i - 1] : undefined;
+            const dtS = prev ? (r.timestamp_ms - prev.timestamp_ms) / 1000 : 0;
+            raw = prev && typeof r.distance_m === "number" && typeof prev.distance_m === "number" && dtS > 0
+              ? Math.max(0, (r.distance_m - prev.distance_m) / dtS)
+              : null;
+          }
           if (raw == null) return [r.timestamp_ms - t0, null];
           if (key === "speed_m_s") return [r.timestamp_ms - t0, convertSpeedMps(raw as number, distanceUnit)];
           if (key === "altitude_m") return [r.timestamp_ms - t0, convertElevationMeters(raw as number, distanceUnit)];
@@ -185,6 +197,21 @@ export function CompareCharts({ compareIds, activities, theme, distanceUnit }: P
     },
   };
 
+  const chartConfigs = [
+    { available: combinedAvailability.hasHeartRate, title: t("compare.heartRate"), unit: "bpm", key: "heart_rate" as keyof RecordPoint },
+    { available: combinedAvailability.hasSpeed, title: t("compare.speed"), unit: speedLabel(distanceUnit), key: "speed_m_s" as keyof RecordPoint },
+    { available: combinedAvailability.hasPower, title: t("compare.power"), unit: "W", key: "power" as keyof RecordPoint },
+    { available: combinedAvailability.hasElevation, title: t("compare.altitude"), unit: elevationLabel(distanceUnit), key: "altitude_m" as keyof RecordPoint },
+  ].filter((chart) => chart.available);
+
+  if (!chartConfigs.length) {
+    return (
+      <div className="empty-state">
+        <span>{t("compare.noAvailableCharts")}</span>
+      </div>
+    );
+  }
+
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
       <div style={{ display: "flex", justifyContent: "flex-end" }}>
@@ -192,10 +219,11 @@ export function CompareCharts({ compareIds, activities, theme, distanceUnit }: P
           {t("compare.resetZoom")}
         </button>
       </div>
-      <div className="panel"><ReactECharts option={createOption(t("compare.heartRate"), "bpm", "heart_rate")} onEvents={zoomEvents} onChartReady={enableChartWheelPageScroll} notMerge style={{ height: 320, width: "100%" }} /></div>
-      <div className="panel"><ReactECharts option={createOption(t("compare.speed"), speedLabel(distanceUnit), "speed_m_s")} onEvents={zoomEvents} onChartReady={enableChartWheelPageScroll} notMerge style={{ height: 320, width: "100%" }} /></div>
-      <div className="panel"><ReactECharts option={createOption(t("compare.power"), "W", "power")} onEvents={zoomEvents} onChartReady={enableChartWheelPageScroll} notMerge style={{ height: 320, width: "100%" }} /></div>
-      <div className="panel"><ReactECharts option={createOption(t("compare.altitude"), elevationLabel(distanceUnit), "altitude_m")} onEvents={zoomEvents} onChartReady={enableChartWheelPageScroll} notMerge style={{ height: 320, width: "100%" }} /></div>
+      {chartConfigs.map((chart) => (
+        <div className="panel" key={String(chart.key)}>
+          <ReactECharts option={createOption(chart.title, chart.unit, chart.key)} onEvents={zoomEvents} onChartReady={enableChartWheelPageScroll} notMerge style={{ height: 320, width: "100%" }} />
+        </div>
+      ))}
     </div>
   );
 }

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -19,6 +19,7 @@ import { isTauri } from "@tauri-apps/api/core";
 import { open } from "@tauri-apps/plugin-dialog";
 import { exportSingleActivity, exportBulkActivities, type ExportFormat, type BulkExportProgress } from "../lib/exportUtils";
 import { useSettingsStore } from "../stores/settingsStore";
+import { getRecordDataAvailability } from "../lib/recordDataAvailability";
 import type { Activity, RecordPoint } from "../types";
 import appIcon from "../assets/app-icon.svg";
 import {
@@ -481,6 +482,9 @@ export function Dashboard({ onLogout }: Props) {
   const filteredSports = Array.from(new Set(filtered.map((a) => a.sport).filter(Boolean)));
   const filteredDevices = Array.from(new Set(filtered.map((a) => a.device).filter(Boolean)));
   const selectedRecords = tab === "overview" ? overviewRecords : records;
+  const selectedAvailability = useMemo(() => getRecordDataAvailability(selectedRecords), [selectedRecords]);
+  const hasTelemetryCharts = selectedAvailability.hasHeartRate || selectedAvailability.hasPace;
+  const hasDetailRoute = selectedAvailability.hasGpsRoute;
   const distanceDivisorValue = distanceDivisor(distanceUnit);
   const distanceSuffix = distanceLabel(distanceUnit);
   const filteredTotalDistanceM = filtered.reduce((sum, a) => sum + a.distance_m, 0);
@@ -1600,10 +1604,14 @@ export function Dashboard({ onLogout }: Props) {
                   ))}
                 </div>
               </div>
-              <div className="detail-grid">
-                <div className="panel"><h3>{t("detail.heartRateAndPace")}</h3><ActivityChart records={selectedRecords} theme={theme} distanceUnit={distanceUnit} heartRateZoneBoundsBpm={selectedMetadata?.heart_rate_zone_bounds_bpm} zoomRange={telemetryZoom} onZoomChange={setTelemetryZoom} lapTimestampsUtc={lapTimestampsUtc} smoothGraphs={smoothGraphs} /></div>
-                <ActivityMap records={selectedRecords} mapStyle={mapStyle} setMapStyle={setMapStyle} lapTimestampsUtc={lapTimestampsUtc} />
-              </div>
+              {(hasTelemetryCharts || hasDetailRoute) && (
+                <div className="detail-grid">
+                  {hasTelemetryCharts && (
+                    <div className="panel"><h3>{t("detail.heartRateAndPace")}</h3><ActivityChart records={selectedRecords} theme={theme} distanceUnit={distanceUnit} heartRateZoneBoundsBpm={selectedMetadata?.heart_rate_zone_bounds_bpm} zoomRange={telemetryZoom} onZoomChange={setTelemetryZoom} lapTimestampsUtc={lapTimestampsUtc} smoothGraphs={smoothGraphs} /></div>
+                  )}
+                  {hasDetailRoute && <ActivityMap records={selectedRecords} mapStyle={mapStyle} setMapStyle={setMapStyle} lapTimestampsUtc={lapTimestampsUtc} />}
+                </div>
+              )}
               <ActivityInsights records={selectedRecords} theme={theme} distanceUnit={distanceUnit} heartRateZoneBoundsBpm={selectedMetadata?.heart_rate_zone_bounds_bpm} zoomRange={telemetryZoom} onZoomChange={setTelemetryZoom} lapTimestampsUtc={lapTimestampsUtc} smoothGraphs={smoothGraphs} />
               {lapRows.length > 0 && (
                 <div className="panel laps-table-panel">

--- a/src/components/OverviewLocationMap.tsx
+++ b/src/components/OverviewLocationMap.tsx
@@ -85,6 +85,7 @@ export function OverviewLocationMap({ records, mapStyle, setMapStyle }: Props) {
       }));
     return { type: "FeatureCollection", features };
   }, [records]);
+  const hasLocations = geojson.features.length > 0;
 
   function fitToData(map: maplibregl.Map) {
     if (!geojson.features.length) return;
@@ -219,7 +220,7 @@ export function OverviewLocationMap({ records, mapStyle, setMapStyle }: Props) {
   }
 
   useEffect(() => {
-    if (!mapContainerRef.current || mapRef.current) return;
+    if (!hasLocations || !mapContainerRef.current || mapRef.current) return;
 
     const map = new maplibregl.Map({
       container: mapContainerRef.current,
@@ -257,11 +258,11 @@ export function OverviewLocationMap({ records, mapStyle, setMapStyle }: Props) {
       map.remove();
       mapRef.current = null;
     };
-  }, []);
+  }, [hasLocations]);
 
   useEffect(() => {
     const map = mapRef.current;
-    if (!map) return;
+    if (!map || !hasLocations) return;
 
     map.setStyle(styleFromMap(mapStyle, theme));
     const onIdle = () => {
@@ -273,11 +274,11 @@ export function OverviewLocationMap({ records, mapStyle, setMapStyle }: Props) {
     return () => {
       map.off("idle", onIdle);
     };
-  }, [mapStyle, theme]);
+  }, [mapStyle, theme, hasLocations]);
 
   useEffect(() => {
     const map = mapRef.current;
-    if (!map) return;
+    if (!map || !hasLocations) return;
 
     if (map.isStyleLoaded()) {
       ensureSourcesAndLayers(map);
@@ -291,7 +292,15 @@ export function OverviewLocationMap({ records, mapStyle, setMapStyle }: Props) {
         map.off("idle", onIdle);
       };
     }
-  }, [geojson]);
+  }, [geojson, hasLocations]);
+
+  useEffect(() => {
+    if (hasLocations || !mapRef.current) return;
+    mapRef.current.remove();
+    mapRef.current = null;
+  }, [hasLocations]);
+
+  if (!hasLocations) return null;
 
   return (
     <div className="panel overview-location-panel">

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -248,6 +248,7 @@
   "trend.duration": "Dauer",
   "compare.selectActivities": "Wählen Sie bis zu 4 Aktivitäten zum Vergleichen.",
   "compare.loading": "Vergleichsdaten werden geladen...",
+  "compare.noAvailableCharts": "Keine vergleichbaren Telemetriedaten verfügbar.",
   "compare.resetZoom": "Zoom zurücksetzen",
   "compare.heartRate": "Herzfrequenz",
   "compare.speed": "Geschwindigkeit",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -282,6 +282,7 @@
 
   "compare.selectActivities": "Select up to 4 activities from the sidebar using the checkboxes to compare them.",
   "compare.loading": "Loading comparison data...",
+  "compare.noAvailableCharts": "No comparable telemetry data available.",
   "compare.resetZoom": "Reset Zoom",
   "compare.heartRate": "Heart Rate",
   "compare.speed": "Speed",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -248,6 +248,7 @@
   "trend.duration": "Duración",
   "compare.selectActivities": "Seleccione hasta 4 actividades para comparar.",
   "compare.loading": "Cargando datos de comparación...",
+  "compare.noAvailableCharts": "No hay datos de telemetría comparables disponibles.",
   "compare.resetZoom": "Restablecer zoom",
   "compare.heartRate": "Frecuencia cardíaca",
   "compare.speed": "Velocidad",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -248,6 +248,7 @@
   "trend.duration": "Durée",
   "compare.selectActivities": "Sélectionnez jusqu'à 4 activités à comparer.",
   "compare.loading": "Chargement des données de comparaison...",
+  "compare.noAvailableCharts": "Aucune donnée de télémétrie comparable disponible.",
   "compare.resetZoom": "Réinitialiser le zoom",
   "compare.heartRate": "Fréquence cardiaque",
   "compare.speed": "Vitesse",

--- a/src/i18n/hu.json
+++ b/src/i18n/hu.json
@@ -248,6 +248,7 @@
   "trend.duration": "Időtartam",
   "compare.selectActivities": "Válasszon max 4 tevékenységet az összehasonlításhoz.",
   "compare.loading": "Összehasonlítási adatok betöltése...",
+  "compare.noAvailableCharts": "Nincs összehasonlítható telemetriai adat.",
   "compare.resetZoom": "Zoom visszaállítás",
   "compare.heartRate": "Pulzus",
   "compare.speed": "Sebesség",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -248,6 +248,7 @@
   "trend.duration": "Durata",
   "compare.selectActivities": "Seleziona fino a 4 attività da confrontare.",
   "compare.loading": "Caricamento dati di confronto...",
+  "compare.noAvailableCharts": "Nessun dato di telemetria confrontabile disponibile.",
   "compare.resetZoom": "Reimposta zoom",
   "compare.heartRate": "Frequenza cardiaca",
   "compare.speed": "Velocità",

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -248,6 +248,7 @@
   "trend.duration": "時間",
   "compare.selectActivities": "比較するために最大4つのアクティビティを選択してください。",
   "compare.loading": "比較データを読み込み中...",
+  "compare.noAvailableCharts": "比較可能なテレメトリデータがありません。",
   "compare.resetZoom": "ズームをリセット",
   "compare.heartRate": "心拍数",
   "compare.speed": "速度",

--- a/src/i18n/ko.json
+++ b/src/i18n/ko.json
@@ -248,6 +248,7 @@
   "trend.duration": "시간",
   "compare.selectActivities": "비교할 활동을 최대 4개 선택하세요.",
   "compare.loading": "비교 데이터 로딩 중...",
+  "compare.noAvailableCharts": "비교 가능한 텔레메트리 데이터가 없습니다.",
   "compare.resetZoom": "줌 초기화",
   "compare.heartRate": "심박수",
   "compare.speed": "속도",

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -248,6 +248,7 @@
   "trend.duration": "Duur",
   "compare.selectActivities": "Selecteer tot 4 activiteiten om te vergelijken.",
   "compare.loading": "Vergelijkingsgegevens laden...",
+  "compare.noAvailableCharts": "Geen vergelijkbare telemetriegegevens beschikbaar.",
   "compare.resetZoom": "Zoom resetten",
   "compare.heartRate": "Hartslag",
   "compare.speed": "Snelheid",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -248,6 +248,7 @@
   "trend.duration": "Czas trwania",
   "compare.selectActivities": "Wybierz do 4 aktywności do porównania.",
   "compare.loading": "Ładowanie danych porównawczych...",
+  "compare.noAvailableCharts": "Brak porównywalnych danych telemetrycznych.",
   "compare.resetZoom": "Resetuj zoom",
   "compare.heartRate": "Tętno",
   "compare.speed": "Prędkość",

--- a/src/i18n/pt.json
+++ b/src/i18n/pt.json
@@ -248,6 +248,7 @@
   "trend.duration": "Duração",
   "compare.selectActivities": "Selecione até 4 atividades para comparar.",
   "compare.loading": "Carregando dados de comparação...",
+  "compare.noAvailableCharts": "Não há dados de telemetria comparáveis disponíveis.",
   "compare.resetZoom": "Redefinir zoom",
   "compare.heartRate": "Frequência cardíaca",
   "compare.speed": "Velocidade",

--- a/src/i18n/tr.json
+++ b/src/i18n/tr.json
@@ -248,6 +248,7 @@
   "trend.duration": "Süre",
   "compare.selectActivities": "Karşılaştırmak için en fazla 4 aktivite seçin.",
   "compare.loading": "Karşılaştırma verileri yükleniyor...",
+  "compare.noAvailableCharts": "Karşılaştırılabilir telemetri verisi yok.",
   "compare.resetZoom": "Yakınlaştırmayı sıfırla",
   "compare.heartRate": "Kalp Atış Hızı",
   "compare.speed": "Hız",

--- a/src/i18n/zh.json
+++ b/src/i18n/zh.json
@@ -248,6 +248,7 @@
   "trend.duration": "时长",
   "compare.selectActivities": "从侧边栏选择最多4项活动进行对比。",
   "compare.loading": "加载对比数据...",
+  "compare.noAvailableCharts": "没有可比较的遥测数据。",
   "compare.resetZoom": "重置缩放",
   "compare.heartRate": "心率",
   "compare.speed": "速度",

--- a/src/lib/recordDataAvailability.ts
+++ b/src/lib/recordDataAvailability.ts
@@ -1,0 +1,94 @@
+import type { RecordPoint } from "../types";
+
+export type RecordDataAvailability = {
+  hasGpsRoute: boolean;
+  hasHeartRate: boolean;
+  hasSpeed: boolean;
+  hasPace: boolean;
+  hasPower: boolean;
+  hasCadence: boolean;
+  hasTemperature: boolean;
+  hasElevation: boolean;
+};
+
+const emptyAvailability: RecordDataAvailability = {
+  hasGpsRoute: false,
+  hasHeartRate: false,
+  hasSpeed: false,
+  hasPace: false,
+  hasPower: false,
+  hasCadence: false,
+  hasTemperature: false,
+  hasElevation: false,
+};
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function hasDerivedSpeed(records: RecordPoint[]): boolean {
+  for (let i = 1; i < records.length; i += 1) {
+    const current = records[i];
+    const previous = records[i - 1];
+    if (
+      isFiniteNumber(current.distance_m) &&
+      isFiniteNumber(previous.distance_m) &&
+      isFiniteNumber(current.timestamp_ms) &&
+      isFiniteNumber(previous.timestamp_ms) &&
+      current.timestamp_ms > previous.timestamp_ms &&
+      current.distance_m > previous.distance_m
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function getRecordDataAvailability(records: RecordPoint[]): RecordDataAvailability {
+  let gpsPointCount = 0;
+  let hasHeartRate = false;
+  let hasSpeed = false;
+  let hasPower = false;
+  let hasCadence = false;
+  let hasTemperature = false;
+  let hasElevation = false;
+
+  for (const record of records) {
+    if (isFiniteNumber(record.latitude) && isFiniteNumber(record.longitude)) gpsPointCount += 1;
+    if (isFiniteNumber(record.heart_rate) && record.heart_rate > 0) hasHeartRate = true;
+    if (isFiniteNumber(record.speed_m_s) && record.speed_m_s > 0) hasSpeed = true;
+    if (isFiniteNumber(record.power) && record.power > 0) hasPower = true;
+    if (isFiniteNumber(record.cadence) && record.cadence > 0) hasCadence = true;
+    if (isFiniteNumber(record.temperature_c)) hasTemperature = true;
+    if (isFiniteNumber(record.altitude_m)) hasElevation = true;
+  }
+
+  hasSpeed = hasSpeed || hasDerivedSpeed(records);
+
+  return {
+    hasGpsRoute: gpsPointCount >= 2,
+    hasHeartRate,
+    hasSpeed,
+    hasPace: hasSpeed,
+    hasPower,
+    hasCadence,
+    hasTemperature,
+    hasElevation,
+  };
+}
+
+export function combineRecordDataAvailability(items: RecordDataAvailability[]): RecordDataAvailability {
+  return items.reduce<RecordDataAvailability>(
+    (combined, item) => ({
+      hasGpsRoute: combined.hasGpsRoute || item.hasGpsRoute,
+      hasHeartRate: combined.hasHeartRate || item.hasHeartRate,
+      hasSpeed: combined.hasSpeed || item.hasSpeed,
+      hasPace: combined.hasPace || item.hasPace,
+      hasPower: combined.hasPower || item.hasPower,
+      hasCadence: combined.hasCadence || item.hasCadence,
+      hasTemperature: combined.hasTemperature || item.hasTemperature,
+      hasElevation: combined.hasElevation || item.hasElevation,
+    }),
+    emptyAvailability
+  );
+}


### PR DESCRIPTION
## Summary

Hides unavailable activity telemetry panels instead of rendering empty charts or map surfaces when the selected activities do not contain the required data streams.

The original elevation fix covered one symptom. The same availability issue also affected the top heart-rate/pace charts, insight charts, individual and overview map panels, route colour modes, and comparison charts.

Closes #43.

## Changes

- Add a shared record data availability helper for GPS routes, heart rate, speed/pace, power, cadence, temperature, and elevation.
- Gate the individual heart-rate/pace panel, GPS route panel, overview location map, and insight panels by available data.
- Keep `0 m` elevation and `0 C` temperature valid by checking finite values instead of truthiness.
- Filter route colour options so unavailable streams cannot be selected for map colouring.
- Render only comparison charts supported by at least one selected activity, with a localized empty state when no comparable telemetry exists.

## Testing

- Ran `git diff --check` on the PR branch.
- Merged the branch into local `main` for integrated validation.
- Rebuilt and deployed the local Docker app from local `main` with `docker/docker-compose-build.yml` plus the local override file.
- Confirmed the frontend `npm run build` completed inside the Docker build.
- Verified the `fit-dashboard` container is running and `http://localhost:8088/` responds with HTTP 200.
