### PR TITLE
Show Normalized Power for cycling activities

### DIFF
--- a/docs/features/active-time-chart-axes.md
+++ b/docs/features/active-time-chart-axes.md
@@ -1,0 +1,194 @@
+# Active-Time Telemetry
+
+## Status
+
+Design proposal for issue #45.
+
+Related issues:
+
+- #23: FIT activity duration uses record span instead of timer time
+- #38: Add distance x-axis option to telemetry charts
+
+## Problem
+
+FIT Dashboard can store an activity duration derived from FIT timer time, while telemetry charts still use elapsed record time and raw telemetry records.
+
+For activities with pauses, manual timer stops, or Auto Pause intervals, those values differ:
+
+- activity duration follows active timer time, matching the user-facing Garmin Connect "Total Time" style value
+- Strava presents the comparable user-facing concept as "Moving Time"
+- telemetry chart Time mode currently follows elapsed record timestamps from the first record to the last record
+- telemetry charts currently include any records captured during stopped or paused intervals
+
+This means a ride can show an activity duration of `4:10:00`, while the chart Time axis runs to `4:36:33`. The difference is stopped or paused time.
+
+Issue #23 fixed the stored duration source. Issue #38 added Time/Distance x-axis support and explicit chart bounds. This proposal covers the remaining semantic gap: supporting active-time telemetry that understands FIT timer start/stop intervals.
+
+## Goals
+
+- Parse FIT timer event messages that represent timer start, stop, stop-all, and resume behaviour.
+- Preserve whether timer intervals were triggered manually or by Auto Pause / auto-resume when the FIT file provides that detail.
+- Persist enough interval metadata to derive active elapsed time for telemetry records.
+- Let telemetry charts use active timer time so the Time axis can end near the displayed activity duration.
+- Exclude stopped-interval telemetry samples from active-time chart data so paused records do not collapse onto a single x-value or distort chart shape.
+- Keep elapsed record time available for diagnostics, export, and possible future UI modes.
+- Keep Distance mode distance semantics unchanged while applying the same active-record filtering to eligible telemetry charts.
+
+## Non-Goals
+
+- Do not change stored activity duration selection from issue #23.
+- Do not infer moving time from GPS speed or displacement as the primary implementation when FIT timer events are available.
+- Do not change distance-axis semantics.
+- Do not change map route geometry.
+- Do not delete stored raw records; stopped-interval filtering should be a chart/view transformation.
+- Do not attempt to make GPX or TCX files fully equivalent to FIT timer events unless their source data explicitly provides comparable pause intervals.
+
+## Source Data
+
+FIT files can contain `event` messages with fields such as:
+
+- `timestamp`
+- `event`, for example `timer`
+- `event_type`, for example `start`, `stop`, or `stop_all`
+- `timer_trigger`, for example `manual` or `auto`
+- `event_group`
+
+Timer intervals should be derived from timer events, not from non-timer markers such as off-course alerts, rider position changes, or vendor-specific marker events.
+
+Manual user timer actions and device Auto Pause / auto-resume events should both contribute to the interval model. The trigger should be retained when available so export and diagnostics can explain why a stopped interval exists.
+
+## Proposed Metadata
+
+Store timer interval metadata in `activities.metadata_json` for imported FIT activities. A first version can keep this in metadata rather than adding first-class relational tables.
+
+Example shape:
+
+```json
+{
+  "timer": {
+    "schema_version": 1,
+    "source": "fit_event_messages",
+    "active_time_supported": true,
+    "intervals_reliable": true,
+    "elapsed_time_s": 16593.398,
+    "timer_time_s": 15000.396,
+    "stopped_time_s": 1593.002,
+    "events": [
+      {
+        "timestamp": "2026-06-11T15:47:25Z",
+        "event": "timer",
+        "event_type": "stop_all",
+        "timer_trigger": "auto"
+      },
+      {
+        "timestamp": "2026-06-11T15:57:16Z",
+        "event": "timer",
+        "event_type": "start",
+        "timer_trigger": "auto"
+      }
+    ],
+    "stopped_intervals": [
+      {
+        "start_ts_utc": "2026-06-11T15:47:25Z",
+        "end_ts_utc": "2026-06-11T15:57:16Z",
+        "duration_s": 591,
+        "trigger": "auto"
+      }
+    ]
+  }
+}
+```
+
+The parser should tolerate incomplete event pairs. If intervals cannot be derived confidently, `active_time_supported` should be `false` or omitted, and charts should continue using elapsed record time.
+
+Derived intervals should be marked reliable only when their computed active duration is reasonably consistent with the FIT timer duration selected for the activity, allowing for normal timestamp rounding differences.
+
+## Active-Time Telemetry Model
+
+The feature should derive active telemetry from timer intervals:
+
+1. Sort timer events by timestamp.
+2. Build stopped intervals from timer stop/stop-all events followed by the next timer start event.
+3. Clamp intervals to the activity record/session time range.
+4. Ignore invalid intervals with missing timestamps, negative duration, or no matching resume event unless a safe end bound is available.
+5. Classify each telemetry record as active or stopped.
+6. For each active telemetry record timestamp, subtract all stopped interval durations that ended before the record.
+
+Stopped intervals should be treated as half-open ranges: `[stop_timestamp, next_start_timestamp)`. A record exactly at the stop timestamp is stopped. A record exactly at the following start timestamp is active.
+
+Stopped-interval records should not be plotted in active-time chart data. If they were kept, every record inside a stopped interval would map to the same active timestamp, creating vertical stacks, duplicate x-values, and chart shapes influenced by pause-time values such as zero speed or recovering heart rate.
+
+This produces active telemetry points with:
+
+- original timestamp
+- active elapsed time
+- elapsed record time
+- distance
+- telemetry values
+- stopped/active classification
+
+The original timestamp and elapsed record time should be preserved for tooltips, export, and diagnostics.
+
+## Chart Behaviour
+
+The existing Time mode should be updated only after the parser, metadata, and active-record filtering support are available.
+
+Expected chart behaviour:
+
+- Time mode uses active elapsed time and active records when reliable timer intervals exist.
+- Time mode falls back to elapsed record time when active intervals are unavailable.
+- Distance mode keeps cumulative distance as its x-axis.
+- Distance mode should use the same active-record filtering as Time mode when reliable timer intervals exist, so stopped samples do not distort telemetry charts.
+- Tooltip headers should show active elapsed time and retain the original timestamp context.
+- Lap markers should use the same x-axis mapping as the chart data.
+- Chart x-axis bounds should continue to use the maximum finite plotted x-value.
+
+A future refinement could expose separate `Elapsed` and `Active` chart time modes. The first implementation can use active telemetry automatically only when reliable FIT timer intervals are present.
+
+The activity map should continue to use the complete route unless a later feature explicitly adds active-only route display.
+
+## Export Behaviour
+
+JSON export should include the timer metadata needed to explain the difference between elapsed and active duration:
+
+- timer event source
+- active-time support flag
+- elapsed time
+- timer time
+- stopped time
+- stopped intervals with trigger information when available
+- per-record active/stopped classification when record-level export adopts active-time fields
+- active elapsed seconds for records when record-level export adopts active-time fields
+
+CSV export does not need to include the full interval list initially, but exported records may later include active elapsed seconds and stopped/active classification if the chart model adopts those values.
+
+## Migration and Reimport
+
+Existing imported activities will not have parsed timer intervals unless they are reimported or explicitly backfilled from the original FIT files.
+
+For a first implementation:
+
+- new imports should populate timer metadata
+- existing DB rows can keep working without migration beyond accepting new metadata keys
+- no destructive data migration is required
+- a future backfill tool can be considered separately
+
+## Validation
+
+Use a Garmin FIT file with known pauses:
+
+- `session.total_timer_time` around `4:10:00`
+- `session.total_elapsed_time` around `4:36:33`
+- stopped time around `26:33`
+- timer events include both manual and automatic triggers
+
+Validation should confirm:
+
+- activity duration still displays timer time
+- metadata includes stopped intervals
+- derived active duration approximately matches the selected FIT timer duration
+- chart Time mode uses active records and ends near the active duration, not elapsed wall-clock duration
+- stopped-interval telemetry samples are not plotted in active-time chart data
+- distance charts keep distance on the x-axis but use the same active-record filtering decision
+- tooltip and lap marker positions remain coherent
+- activities without reliable timer intervals fall back to elapsed record time

--- a/docs/features/active-time-chart-axes.md
+++ b/docs/features/active-time-chart-axes.md
@@ -2,7 +2,9 @@
 
 ## Status
 
-Design proposal for issue #45.
+Implemented design for issue #45.
+
+This branch is intentionally stacked on the issue #23 duration fix and issue #38 chart Time/Distance axis work. The active-time implementation builds on both behaviours.
 
 Related issues:
 
@@ -157,10 +159,10 @@ JSON export should include the timer metadata needed to explain the difference b
 - timer time
 - stopped time
 - stopped intervals with trigger information when available
-- per-record active/stopped classification when record-level export adopts active-time fields
-- active elapsed seconds for records when record-level export adopts active-time fields
+- per-record active/stopped classification as a future export enhancement
+- active elapsed seconds for records as a future export enhancement
 
-CSV export does not need to include the full interval list initially, but exported records may later include active elapsed seconds and stopped/active classification if the chart model adopts those values.
+The first implementation includes the parsed `metadata_json` object in JSON export so timer events and stopped intervals are available for diagnostics. CSV export does not include the full interval list initially, but exported records may later include active elapsed seconds and stopped/active classification.
 
 ## Migration and Reimport
 

--- a/docs/features/chart-distance-axis.md
+++ b/docs/features/chart-distance-axis.md
@@ -1,0 +1,161 @@
+# Individual Chart Distance Axis Design
+
+## Summary
+
+Add a control on the Individual page that lets users switch eligible telemetry charts between a Time x-axis and a Distance x-axis.
+
+This feature applies only to time-based telemetry line charts. The effort heatmap is excluded because it is intentionally binned by elapsed minutes rather than plotted as point-by-point telemetry.
+
+## Goals
+
+- Let users inspect activity telemetry by either elapsed time or cumulative distance.
+- Keep one shared x-axis mode across all eligible Individual page telemetry charts.
+- Preserve existing zoom, smoothing, lap marker, tooltip, and unit behaviour as much as possible.
+- Avoid backend or parser changes unless frontend data proves insufficient.
+
+## Non-Goals
+
+- Do not change overview charts, comparison charts, maps, lap tables, or exports.
+- Do not convert distribution charts to distance mode.
+- Do not include the effort heatmap in this feature.
+- Do not change the stored activity or record schema.
+
+## Eligible Charts
+
+The following Individual page charts should support the Time/Distance x-axis toggle:
+
+- Heart Rate
+- Pace
+- Speed Trend
+- Cadence
+- Cadence and Power
+- Elevation
+
+The following Individual page charts are not time-based telemetry line charts and should not change:
+
+- Heart Rate Zone Time pie chart
+- Heart Rate histogram
+- Power vs Heart Rate scatter chart
+- Effort heatmap
+
+## Existing Data
+
+`RecordPoint` already includes `distance_m`, so the frontend has the core data needed for distance-axis charting.
+
+Downsampled records currently return `distance_m` using `MAX(distance_m)` for each time bucket. That is acceptable for a cumulative distance x-axis because it keeps each bucket at the furthest known distance in that interval.
+
+The parser also derives cumulative distance from GPS points when an activity file has no native distance field. Activities without usable distance data can still exist, so the frontend needs a fallback state.
+
+## User Experience
+
+Add a compact segmented control in the Individual page detail header near the existing Smooth graphs and Reset Zoom controls:
+
+- Time
+- Distance
+
+Default mode is Time.
+
+The selected x-axis mode is local UI state. It should not persist across sessions in the initial implementation. This matches the existing Individual page chart controls, such as zoom and graph smoothing, which are held in `Dashboard` state rather than stored in global settings.
+
+When Distance is selected:
+
+- Eligible chart x-axes display cumulative distance in the user-selected distance unit.
+- Tooltips still show elapsed time and absolute clock time for context.
+- Tooltips should also show distance where useful.
+- Lap markers move to their corresponding cumulative distance positions.
+
+When an activity has no usable distance data:
+
+- Reset the mode to Time when switching to that activity.
+- Disable Distance for that activity.
+- Prefer disabling Distance with a concise tooltip over silently accepting a mode that cannot be rendered.
+
+## Axis Model
+
+Introduce a frontend type such as:
+
+```ts
+type TelemetryXAxisMode = "time" | "distance";
+```
+
+For each record, build a common chart point context:
+
+```ts
+type TelemetryPoint = {
+  x: number;
+  relMs: number;
+  timestampMs: number;
+  distanceMeters: number | null;
+};
+```
+
+For Time mode:
+
+- `x = relMs`
+- each axis tick uses elapsed time formatting
+
+For Distance mode:
+
+- `x = convertDistanceMeters(distanceMeters, distanceUnit)`
+- each axis tick uses distance formatting with the active distance unit, such as `1.25 km` or `0.75 mi`
+
+Series should keep additional values in the row so tooltip formatters can show both time and distance regardless of current x-axis mode.
+
+## Lap Markers
+
+Current lap markers are timestamp based. Distance mode needs lap marker x-values derived from record distance.
+
+Recommended approach:
+
+1. Parse each lap timestamp.
+2. Find the nearest surrounding records by timestamp.
+3. Interpolate distance between the surrounding records when both have finite `distance_m`.
+4. Fall back to the nearest record distance if interpolation is not possible.
+5. Omit the marker if no finite distance is available.
+
+Time mode can keep the current elapsed-time marker calculation.
+
+## Zoom Behaviour
+
+Current chart zoom state is stored as ECharts percentage ranges (`start` and `end`), not raw x-axis values. That can remain shared across Time and Distance modes.
+
+Changing x-axis mode should not require resetting zoom. The same visible percentage range can be applied to the newly selected axis.
+
+The existing Reset Zoom button should continue to clear the shared zoom state.
+
+## Smoothing
+
+Smoothing currently uses a dynamic window based on record count, elapsed duration, and visible zoom percentage.
+
+For the initial implementation, keep the existing smoothing calculation. Distance mode changes the x-coordinate but not the sample order, so rolling averages remain valid.
+
+A future refinement could calculate the smoothing window from visible distance instead of visible duration, but that is not required for this feature.
+
+## Implementation Plan
+
+1. Add `TelemetryXAxisMode` state to `Dashboard`.
+2. Add Time/Distance segmented control to the Individual page detail header.
+3. Pass `xAxisMode` into `ActivityChart` and `ActivityInsights`.
+4. Add shared x-axis formatting helpers for time and distance labels.
+5. Refactor `ActivityChart` series data so Heart Rate and Pace use the selected x-axis value.
+6. Refactor `ActivityInsights` time-based line chart data for Speed Trend, Cadence, Power, and Elevation.
+7. Update tooltip headers to include both time and distance context.
+8. Update lap marker creation to support both time and distance modes.
+9. Reset the x-axis mode to Time when the selected activity has no finite distance samples.
+10. Leave the effort heatmap unchanged and document that it is excluded because it is minute-binned.
+11. Add translation keys for the new control labels and tooltip text.
+
+## Validation
+
+Manual validation should cover:
+
+- Time mode remains visually unchanged from current behaviour.
+- Distance mode works on an activity with complete distance samples.
+- Distance mode is disabled or unavailable for an activity with no finite distance samples.
+- Switching to an activity with no finite distance samples resets the mode to Time.
+- Lap markers appear in correct positions in both modes.
+- Shared zoom still affects all eligible time-based charts.
+- Reset Zoom works in both modes.
+- Smooth graphs still applies in both modes.
+- The effort heatmap remains time-binned and is unaffected by the toggle.
+

--- a/docs/features/chart-distance-axis.md
+++ b/docs/features/chart-distance-axis.md
@@ -10,6 +10,7 @@ This feature applies only to time-based telemetry line charts. The effort heatma
 
 - Let users inspect activity telemetry by either elapsed time or cumulative distance.
 - Keep one shared x-axis mode across all eligible Individual page telemetry charts.
+- Keep chart x-axes bounded to the plotted telemetry extent so charts do not show blank trailing whitespace after the final sample.
 - Preserve existing zoom, smoothing, lap marker, tooltip, and unit behaviour as much as possible.
 - Avoid backend or parser changes unless frontend data proves insufficient.
 
@@ -93,13 +94,34 @@ For Time mode:
 
 - `x = relMs`
 - each axis tick uses elapsed time formatting
+- the x-axis domain starts at `0` and ends at the maximum finite plotted elapsed time
 
 For Distance mode:
 
 - `x = convertDistanceMeters(distanceMeters, distanceUnit)`
 - each axis tick uses distance formatting with the active distance unit, such as `1.25 km` or `0.75 mi`
+- the x-axis domain starts at `0` and ends at the maximum finite plotted distance in the active distance unit
 
 Series should keep additional values in the row so tooltip formatters can show both time and distance regardless of current x-axis mode.
+
+## Axis Bounds
+
+The telemetry line charts should use explicit x-axis bounds instead of relying on ECharts automatic value-axis extent.
+
+Without explicit bounds, ECharts rounds the domain to visually neat tick intervals. For long activities, a final sample at `4:36:33` can produce a visible `5:00:00` endpoint. That creates blank whitespace after the data and can make the chart appear inconsistent with the activity duration shown elsewhere in the UI.
+
+For both Time and Distance modes:
+
+- set `xAxis.min = 0`
+- compute `xAxis.max` from finite x-values that are actually present in the plotted telemetry series
+- only set `xAxis.max` when the computed value is finite and greater than `0`
+- keep the chart data unchanged; this is an axis display bound, not a parser, record, or duration change
+
+For Time mode, the max should be the maximum finite elapsed timestamp represented by the plotted telemetry points. This preserves elapsed record-time chart semantics, including stopped-time gaps when records span them, while preventing ECharts from extending the visible axis beyond the last sample.
+
+For Distance mode, the max should be the maximum finite cumulative distance represented by the plotted telemetry points in the current distance unit. This avoids trailing distance whitespace such as showing a rounded `105 km` endpoint when the final plotted point is `102.25 km`.
+
+This intentionally favours exact telemetry extent over nice rounded axis endpoints for Individual telemetry charts.
 
 ## Lap Markers
 
@@ -141,9 +163,10 @@ A future refinement could calculate the smoothing window from visible distance i
 6. Refactor `ActivityInsights` time-based line chart data for Speed Trend, Cadence, Power, and Elevation.
 7. Update tooltip headers to include both time and distance context.
 8. Update lap marker creation to support both time and distance modes.
-9. Reset the x-axis mode to Time when the selected activity has no finite distance samples.
-10. Leave the effort heatmap unchanged and document that it is excluded because it is minute-binned.
-11. Add translation keys for the new control labels and tooltip text.
+9. Add shared x-axis bound helpers so eligible telemetry charts set `min = 0` and `max` to the maximum finite plotted x-value for both Time and Distance modes.
+10. Reset the x-axis mode to Time when the selected activity has no finite distance samples.
+11. Leave the effort heatmap unchanged and document that it is excluded because it is minute-binned.
+12. Add translation keys for the new control labels and tooltip text.
 
 ## Validation
 
@@ -151,6 +174,8 @@ Manual validation should cover:
 
 - Time mode remains visually unchanged from current behaviour.
 - Distance mode works on an activity with complete distance samples.
+- Time mode does not show blank trailing whitespace after the maximum finite telemetry x-value, for example an activity ending around `4:36:33` should not visually extend to `5:00:00`.
+- Distance mode does not show blank trailing whitespace after the maximum finite distance sample.
 - Distance mode is disabled or unavailable for an activity with no finite distance samples.
 - Switching to an activity with no finite distance samples resets the mode to Time.
 - Lap markers appear in correct positions in both modes.

--- a/docs/features/chart-distance-axis.md
+++ b/docs/features/chart-distance-axis.md
@@ -158,4 +158,3 @@ Manual validation should cover:
 - Reset Zoom works in both modes.
 - Smooth graphs still applies in both modes.
 - The effort heatmap remains time-binned and is unaffected by the toggle.
-

--- a/src-tauri/src/fit_parser.rs
+++ b/src-tauri/src/fit_parser.rs
@@ -242,6 +242,72 @@ fn total_distance_m(points: &[RecordPoint]) -> f64 {
         .unwrap_or(0.0)
 }
 
+fn valid_duration_s(value: Option<f64>) -> Option<f64> {
+    value.filter(|v| v.is_finite() && *v > 0.0)
+}
+
+fn add_valid_duration_s(total: &mut Option<f64>, value: Option<f64>) {
+    if let Some(duration) = valid_duration_s(value) {
+        *total = Some(total.unwrap_or(0.0) + duration);
+    }
+}
+
+fn select_fit_duration_s(
+    session_total_timer_time_sum_s: Option<f64>,
+    activity_total_timer_time_s: Option<f64>,
+    lap_total_timer_time_sum_s: Option<f64>,
+    session_total_elapsed_time_sum_s: Option<f64>,
+    record_span_duration_s: f64,
+) -> (f64, &'static str) {
+    if let Some(duration) = valid_duration_s(session_total_timer_time_sum_s) {
+        return (duration, "sessions.total_timer_time_sum");
+    }
+    if let Some(duration) = valid_duration_s(activity_total_timer_time_s) {
+        return (duration, "activity.total_timer_time");
+    }
+    if let Some(duration) = valid_duration_s(lap_total_timer_time_sum_s) {
+        return (duration, "laps.total_timer_time_sum");
+    }
+    if let Some(duration) = valid_duration_s(session_total_elapsed_time_sum_s) {
+        return (duration, "sessions.total_elapsed_time_sum");
+    }
+
+    (record_span_duration_s.max(0.0), "record_timestamp_span")
+}
+
+fn select_fit_time_range_ms(
+    record_start_ts: i64,
+    record_end_ts: i64,
+    session_start_ts: Option<i64>,
+    session_end_ts: Option<i64>,
+    duration_s: f64,
+) -> (i64, i64) {
+    let start_ts = session_start_ts.unwrap_or(record_start_ts);
+    let mut end_ts = session_end_ts.unwrap_or(record_end_ts).max(start_ts);
+    let current_span_ms = end_ts - start_ts;
+    let duration_ms = (duration_s * 1000.0).round();
+
+    if duration_ms.is_finite() && duration_ms > current_span_ms as f64 {
+        if let Some(duration_end_ts) = start_ts.checked_add(duration_ms as i64) {
+            end_ts = duration_end_ts;
+        }
+    }
+
+    (start_ts, end_ts)
+}
+
+fn update_min_ts(slot: &mut Option<i64>, value: Option<i64>) {
+    if let Some(ts) = value {
+        *slot = Some(slot.map_or(ts, |current| current.min(ts)));
+    }
+}
+
+fn update_max_ts(slot: &mut Option<i64>, value: Option<i64>) {
+    if let Some(ts) = value {
+        *slot = Some(slot.map_or(ts, |current| current.max(ts)));
+    }
+}
+
 fn first_valid_coordinates(points: &[RecordPoint]) -> (Option<f64>, Option<f64>) {
     if let Some(point) = points
         .iter()
@@ -305,9 +371,15 @@ fn parse_fit_bytes(file_name: &str, bytes: &[u8]) -> Result<ParsedActivity> {
     let mut session_avg_heart_rate: Option<i64> = None;
     let mut session_max_cadence: Option<i64> = None;
     let mut session_avg_cadence: Option<i64> = None;
-    let mut session_total_elapsed_time_s: Option<f64> = None;
+    let mut session_count: i64 = 0;
+    let mut session_start_ts: Option<i64> = None;
+    let mut session_end_ts: Option<i64> = None;
+    let mut session_total_elapsed_time_sum_s: Option<f64> = None;
+    let mut session_total_timer_time_sum_s: Option<f64> = None;
     let mut session_total_distance_m: Option<f64> = None;
     let mut session_total_calories: Option<i64> = None;
+    let mut activity_total_timer_time_s: Option<f64> = None;
+    let mut lap_total_timer_time_sum_s: Option<f64> = None;
     let mut lap_ranges: Vec<serde_json::Value> = Vec::new();
     let mut heart_rate_zone_bounds_bpm: Vec<i64> = Vec::new();
 
@@ -374,9 +446,16 @@ fn parse_fit_bytes(file_name: &str, bytes: &[u8]) -> Result<ParsedActivity> {
                 });
             }
         } else if rec.kind() == MesgNum::Session {
+            session_count += 1;
             for field in rec.fields() {
                 match field.name() {
                     "sport" => sport = value_string(field.value()).to_lowercase(),
+                    "start_time" => {
+                        update_min_ts(&mut session_start_ts, value_timestamp_ms(field.value()))
+                    }
+                    "timestamp" => {
+                        update_max_ts(&mut session_end_ts, value_timestamp_ms(field.value()))
+                    }
                     "beginning_body_battery" | "start_body_battery" => {
                         session_beginning_body_battery = value_i64(field.value())
                     }
@@ -387,7 +466,18 @@ fn parse_fit_bytes(file_name: &str, bytes: &[u8]) -> Result<ParsedActivity> {
                     "avg_heart_rate" => session_avg_heart_rate = value_i64(field.value()),
                     "max_cadence" => session_max_cadence = value_i64(field.value()),
                     "avg_cadence" => session_avg_cadence = value_i64(field.value()),
-                    "total_elapsed_time" => session_total_elapsed_time_s = value_f64(field.value()),
+                    "total_elapsed_time" => {
+                        add_valid_duration_s(
+                            &mut session_total_elapsed_time_sum_s,
+                            value_f64(field.value()),
+                        )
+                    }
+                    "total_timer_time" => {
+                        add_valid_duration_s(
+                            &mut session_total_timer_time_sum_s,
+                            value_f64(field.value()),
+                        )
+                    }
                     "total_distance" => session_total_distance_m = value_f64(field.value()),
                     "total_calories" => session_total_calories = value_i64(field.value()),
                     _ => {}
@@ -493,6 +583,12 @@ fn parse_fit_bytes(file_name: &str, bytes: &[u8]) -> Result<ParsedActivity> {
                     }
                 }
             }
+        } else if rec.kind() == MesgNum::Activity {
+            for field in rec.fields() {
+                if field.name() == "total_timer_time" {
+                    activity_total_timer_time_s = value_f64(field.value());
+                }
+            }
         } else if rec.kind() == MesgNum::Lap {
             let mut lap_start_ms: Option<i64> = None;
             let mut lap_end_ms: Option<i64> = None;
@@ -543,6 +639,10 @@ fn parse_fit_bytes(file_name: &str, bytes: &[u8]) -> Result<ParsedActivity> {
                     "total_calories" => lap_total_calories = value_i64(field.value()),
                     _ => {}
                 }
+            }
+
+            if let Some(duration) = valid_duration_s(lap_total_timer_time_s) {
+                lap_total_timer_time_sum_s = Some(lap_total_timer_time_sum_s.unwrap_or(0.0) + duration);
             }
 
             lap_ranges.push(serde_json::json!({
@@ -607,13 +707,27 @@ fn parse_fit_bytes(file_name: &str, bytes: &[u8]) -> Result<ParsedActivity> {
         }
     }
 
-    let start_ts = min_ts.ok_or_else(|| anyhow!("FIT file had no timestamped records"))?;
-    let end_ts = max_ts.unwrap_or(start_ts);
+    let record_start_ts = min_ts.ok_or_else(|| anyhow!("FIT file had no timestamped records"))?;
+    let record_end_ts = max_ts.unwrap_or(record_start_ts);
 
     derive_distance_if_missing(&mut points);
     derive_speed_if_missing(&mut points);
 
-    let duration_s = ((end_ts - start_ts).max(0) as f64) / 1000.0;
+    let record_span_duration_s = ((record_end_ts - record_start_ts).max(0) as f64) / 1000.0;
+    let (duration_s, duration_source) = select_fit_duration_s(
+        session_total_timer_time_sum_s,
+        activity_total_timer_time_s,
+        lap_total_timer_time_sum_s,
+        session_total_elapsed_time_sum_s,
+        record_span_duration_s,
+    );
+    let (start_ts, end_ts) = select_fit_time_range_ms(
+        record_start_ts,
+        record_end_ts,
+        session_start_ts,
+        session_end_ts,
+        duration_s,
+    );
     let distance_m = total_distance_m(&points);
     let (start_latitude, start_longitude) = first_valid_coordinates(&points);
 
@@ -639,6 +753,12 @@ fn parse_fit_bytes(file_name: &str, bytes: &[u8]) -> Result<ParsedActivity> {
         "record_count": points.len(),
         "device": device,
         "sport": sport,
+        "duration_source": duration_source,
+        "record_span_duration_s": record_span_duration_s,
+        "record_start_ts_utc": chrono::DateTime::from_timestamp_millis(record_start_ts)
+            .map(|dt| dt.to_rfc3339()),
+        "record_end_ts_utc": chrono::DateTime::from_timestamp_millis(record_end_ts)
+            .map(|dt| dt.to_rfc3339()),
         "source_format": "fit",
         "file_id": {
             "product_name": file_id_combined_name,
@@ -653,15 +773,26 @@ fn parse_fit_bytes(file_name: &str, bytes: &[u8]) -> Result<ParsedActivity> {
         "activity_metrics": {
             "vo2_max": vo2_max
         },
+        "activity": {
+            "total_timer_time_s": activity_total_timer_time_s
+        },
         "heart_rate_zone_bounds_bpm": heart_rate_zone_bounds_bpm,
         "session": {
+            "count": session_count,
+            "start_ts_utc": session_start_ts
+                .and_then(chrono::DateTime::from_timestamp_millis)
+                .map(|dt| dt.to_rfc3339()),
+            "end_ts_utc": session_end_ts
+                .and_then(chrono::DateTime::from_timestamp_millis)
+                .map(|dt| dt.to_rfc3339()),
             "beginning_body_battery": session_beginning_body_battery,
             "ending_body_battery": session_ending_body_battery,
             "max_heart_rate": session_max_heart_rate,
             "avg_heart_rate": session_avg_heart_rate,
             "max_cadence": session_max_cadence,
             "avg_cadence": session_avg_cadence,
-            "total_elapsed_time_s": session_total_elapsed_time_s,
+            "total_elapsed_time_s": session_total_elapsed_time_sum_s,
+            "total_timer_time_s": session_total_timer_time_sum_s,
             "total_distance_m": session_total_distance_m,
             "total_calories": session_total_calories
         },
@@ -978,4 +1109,125 @@ fn parse_gpx_bytes(file_name: &str, bytes: &[u8]) -> Result<ParsedActivity> {
         records: points,
         metadata_json,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fit_duration_accumulates_valid_session_timer_values() {
+        let mut total = None;
+        add_valid_duration_s(&mut total, Some(1_000.0));
+        add_valid_duration_s(&mut total, Some(0.0));
+        add_valid_duration_s(&mut total, Some(1_651.675));
+        add_valid_duration_s(&mut total, Some(f64::NAN));
+
+        assert!((total.unwrap() - 2_651.675).abs() < 0.000_001);
+    }
+
+    #[test]
+    fn fit_duration_prefers_session_timer_time_sum() {
+        let (duration, source) = select_fit_duration_s(
+            Some(2_651.675),
+            Some(2_700.0),
+            Some(2_700.0),
+            Some(2_705.309),
+            2_705.0,
+        );
+
+        assert_eq!(duration, 2_651.675);
+        assert_eq!(source, "sessions.total_timer_time_sum");
+    }
+
+    #[test]
+    fn fit_duration_uses_activity_timer_before_lap_sum() {
+        let (duration, source) = select_fit_duration_s(
+            None,
+            Some(606_452.96),
+            Some(3_217.111),
+            Some(606_452.96),
+            3_217.0,
+        );
+
+        assert_eq!(duration, 606_452.96);
+        assert_eq!(source, "activity.total_timer_time");
+    }
+
+    #[test]
+    fn fit_duration_uses_lap_timer_sum_before_elapsed_time() {
+        let (duration, source) = select_fit_duration_s(
+            None,
+            None,
+            Some(2_651.675),
+            Some(2_705.309),
+            2_705.0,
+        );
+
+        assert_eq!(duration, 2_651.675);
+        assert_eq!(source, "laps.total_timer_time_sum");
+    }
+
+    #[test]
+    fn fit_duration_falls_back_to_elapsed_then_record_span() {
+        let (elapsed_duration, elapsed_source) = select_fit_duration_s(
+            None,
+            None,
+            None,
+            Some(2_705.309),
+            2_705.0,
+        );
+        assert_eq!(elapsed_duration, 2_705.309);
+        assert_eq!(elapsed_source, "sessions.total_elapsed_time_sum");
+
+        let (record_duration, record_source) =
+            select_fit_duration_s(None, None, None, None, 2_705.0);
+        assert_eq!(record_duration, 2_705.0);
+        assert_eq!(record_source, "record_timestamp_span");
+    }
+
+    #[test]
+    fn fit_duration_ignores_zero_or_invalid_timer_values() {
+        let (duration, source) = select_fit_duration_s(
+            Some(0.0),
+            Some(f64::NAN),
+            Some(-1.0),
+            Some(2_705.309),
+            2_705.0,
+        );
+
+        assert_eq!(duration, 2_705.309);
+        assert_eq!(source, "sessions.total_elapsed_time_sum");
+    }
+
+    #[test]
+    fn fit_time_range_uses_session_bounds_when_available() {
+        let (start_ts, end_ts) = select_fit_time_range_ms(
+            10_000,
+            70_000,
+            Some(0),
+            Some(120_000),
+            60.0,
+        );
+
+        assert_eq!(start_ts, 0);
+        assert_eq!(end_ts, 120_000);
+    }
+
+    #[test]
+    fn fit_time_range_extends_sparse_record_range_to_duration() {
+        let (start_ts, end_ts) = select_fit_time_range_ms(0, 60_000, None, None, 120.0);
+
+        assert_eq!(start_ts, 0);
+        assert_eq!(end_ts, 120_000);
+    }
+
+    #[test]
+    fn fit_time_range_does_not_shorten_elapsed_record_range() {
+        let (start_ts, end_ts) =
+            select_fit_time_range_ms(0, 2_705_309, None, None, 2_651.675);
+
+        assert_eq!(start_ts, 0);
+        assert_eq!(end_ts, 2_705_309);
+    }
 }

--- a/src-tauri/src/fit_parser.rs
+++ b/src-tauri/src/fit_parser.rs
@@ -532,6 +532,7 @@ fn parse_fit_bytes(file_name: &str, bytes: &[u8]) -> Result<ParsedActivity> {
     let mut session_total_timer_time_sum_s: Option<f64> = None;
     let mut session_total_distance_m: Option<f64> = None;
     let mut session_total_calories: Option<i64> = None;
+    let mut session_normalized_power: Option<i64> = None;
     let mut activity_total_timer_time_s: Option<f64> = None;
     let mut lap_total_timer_time_sum_s: Option<f64> = None;
     let mut lap_ranges: Vec<serde_json::Value> = Vec::new();
@@ -635,6 +636,7 @@ fn parse_fit_bytes(file_name: &str, bytes: &[u8]) -> Result<ParsedActivity> {
                     }
                     "total_distance" => session_total_distance_m = value_f64(field.value()),
                     "total_calories" => session_total_calories = value_i64(field.value()),
+                    "normalized_power" => session_normalized_power = value_i64(field.value()),
                     _ => {}
                 }
             }
@@ -786,6 +788,7 @@ fn parse_fit_bytes(file_name: &str, bytes: &[u8]) -> Result<ParsedActivity> {
             let mut lap_max_cadence: Option<i64> = None;
             let mut lap_total_calories: Option<i64> = None;
             let mut lap_best_speed_m_s: Option<f64> = None;
+            let mut lap_normalized_power: Option<i64> = None;
             for field in rec.fields() {
                 match field.name() {
                     "start_time" => lap_start_ms = value_timestamp_ms(field.value()),
@@ -818,6 +821,7 @@ fn parse_fit_bytes(file_name: &str, bytes: &[u8]) -> Result<ParsedActivity> {
                     "avg_cadence" => lap_avg_cadence = value_i64(field.value()),
                     "max_cadence" => lap_max_cadence = value_i64(field.value()),
                     "total_calories" => lap_total_calories = value_i64(field.value()),
+                    "normalized_power" => lap_normalized_power = value_i64(field.value()),
                     _ => {}
                 }
             }
@@ -845,7 +849,8 @@ fn parse_fit_bytes(file_name: &str, bytes: &[u8]) -> Result<ParsedActivity> {
                 "avg_cadence": lap_avg_cadence,
                 "max_cadence": lap_max_cadence,
                 "total_calories": lap_total_calories,
-                "best_speed_m_s": lap_best_speed_m_s
+                "best_speed_m_s": lap_best_speed_m_s,
+                "normalized_power": lap_normalized_power
             }));
         }
 
@@ -983,7 +988,8 @@ fn parse_fit_bytes(file_name: &str, bytes: &[u8]) -> Result<ParsedActivity> {
             "total_elapsed_time_s": session_total_elapsed_time_sum_s,
             "total_timer_time_s": session_total_timer_time_sum_s,
             "total_distance_m": session_total_distance_m,
-            "total_calories": session_total_calories
+            "total_calories": session_total_calories,
+            "normalized_power": session_normalized_power
         },
         "laps": lap_ranges
     })

--- a/src-tauri/src/fit_parser.rs
+++ b/src-tauri/src/fit_parser.rs
@@ -7,6 +7,23 @@ use sha2::{Digest, Sha256};
 use crate::models::{ParsedActivity, RecordPoint};
 
 const NON_ACTIVITY_FIT_MARKER: &str = "non-activity-fit:";
+const TIMER_INTERVAL_TOLERANCE_S: f64 = 5.0;
+
+#[derive(Clone, Debug, PartialEq)]
+struct TimerEvent {
+    timestamp_ms: i64,
+    event: String,
+    event_type: String,
+    timer_trigger: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+struct StoppedInterval {
+    start_ms: i64,
+    end_ms: i64,
+    trigger: Option<String>,
+    resume_trigger: Option<String>,
+}
 
 pub fn is_non_activity_fit_error(err: &anyhow::Error) -> bool {
     err.chain()
@@ -296,6 +313,143 @@ fn select_fit_time_range_ms(
     (start_ts, end_ts)
 }
 
+fn normalize_fit_token(raw: &str) -> Option<String> {
+    let value = raw.trim().to_lowercase().replace([' ', '-'], "_");
+    if value.is_empty() {
+        None
+    } else {
+        Some(value)
+    }
+}
+
+fn fit_event_name(value: &Value) -> Option<String> {
+    let raw = normalize_fit_token(&value_string(value))?;
+    Some(match raw.as_str() {
+        "0" => "timer".to_string(),
+        _ => raw,
+    })
+}
+
+fn fit_event_type_name(value: &Value) -> Option<String> {
+    let raw = normalize_fit_token(&value_string(value))?;
+    Some(match raw.as_str() {
+        "0" => "start".to_string(),
+        "1" => "stop".to_string(),
+        "4" => "stop_all".to_string(),
+        "8" => "stop_disable".to_string(),
+        "9" => "stop_disable_all".to_string(),
+        _ => raw,
+    })
+}
+
+fn fit_timer_trigger_name(value: &Value) -> Option<String> {
+    let raw = normalize_fit_token(&value_string(value))?;
+    Some(match raw.as_str() {
+        "0" => "manual".to_string(),
+        "1" => "auto".to_string(),
+        "2" => "fitness_equipment".to_string(),
+        _ => raw,
+    })
+}
+
+fn is_timer_start_event(event_type: &str) -> bool {
+    matches!(event_type, "start" | "start_all")
+}
+
+fn is_timer_stop_event(event_type: &str) -> bool {
+    matches!(event_type, "stop" | "stop_all" | "stop_disable" | "stop_disable_all")
+}
+
+fn timestamp_ms_to_rfc3339(ts: i64) -> Option<String> {
+    chrono::DateTime::from_timestamp_millis(ts).map(|dt| dt.to_rfc3339())
+}
+
+fn build_stopped_intervals(
+    timer_events: &[TimerEvent],
+    start_bound_ms: i64,
+    end_bound_ms: i64,
+) -> Vec<StoppedInterval> {
+    let mut events = timer_events.to_vec();
+    events.sort_by_key(|event| event.timestamp_ms);
+
+    let mut stopped_start: Option<TimerEvent> = None;
+    let mut intervals = Vec::new();
+
+    for event in events {
+        if event.event != "timer" {
+            continue;
+        }
+
+        if is_timer_stop_event(&event.event_type) {
+            if stopped_start.is_none() {
+                stopped_start = Some(event);
+            }
+            continue;
+        }
+
+        if is_timer_start_event(&event.event_type) {
+            let Some(stop_event) = stopped_start.take() else {
+                continue;
+            };
+
+            let start_ms = stop_event.timestamp_ms.max(start_bound_ms);
+            let end_ms = event.timestamp_ms.min(end_bound_ms);
+            if end_ms > start_ms {
+                intervals.push(StoppedInterval {
+                    start_ms,
+                    end_ms,
+                    trigger: stop_event.timer_trigger,
+                    resume_trigger: event.timer_trigger,
+                });
+            }
+        }
+    }
+
+    intervals
+}
+
+fn build_timer_metadata(
+    timer_events: &[TimerEvent],
+    record_start_ts: i64,
+    record_end_ts: i64,
+    elapsed_time_s: Option<f64>,
+    timer_time_s: f64,
+) -> serde_json::Value {
+    let elapsed_time_s = valid_duration_s(elapsed_time_s)
+        .unwrap_or_else(|| ((record_end_ts - record_start_ts).max(0) as f64) / 1000.0);
+    let intervals = build_stopped_intervals(timer_events, record_start_ts, record_end_ts);
+    let stopped_time_s: f64 = intervals
+        .iter()
+        .map(|interval| ((interval.end_ms - interval.start_ms).max(0) as f64) / 1000.0)
+        .sum();
+    let derived_timer_time_s = (elapsed_time_s - stopped_time_s).max(0.0);
+    let intervals_reliable = !intervals.is_empty()
+        && (derived_timer_time_s - timer_time_s).abs() <= TIMER_INTERVAL_TOLERANCE_S;
+
+    serde_json::json!({
+        "schema_version": 1,
+        "source": "fit_event_messages",
+        "active_time_supported": intervals_reliable,
+        "intervals_reliable": intervals_reliable,
+        "elapsed_time_s": elapsed_time_s,
+        "timer_time_s": timer_time_s,
+        "stopped_time_s": stopped_time_s,
+        "events": timer_events.iter().map(|event| serde_json::json!({
+            "timestamp": timestamp_ms_to_rfc3339(event.timestamp_ms),
+            "event": event.event,
+            "event_type": event.event_type,
+            "timer_trigger": event.timer_trigger
+        })).collect::<Vec<_>>(),
+        "stopped_intervals": intervals.iter().map(|interval| serde_json::json!({
+            "start_ts_utc": timestamp_ms_to_rfc3339(interval.start_ms),
+            "end_ts_utc": timestamp_ms_to_rfc3339(interval.end_ms),
+            "duration_s": ((interval.end_ms - interval.start_ms).max(0) as f64) / 1000.0,
+            "trigger": interval.trigger,
+            "resume_trigger": interval.resume_trigger
+        })).collect::<Vec<_>>()
+    })
+}
+
 fn update_min_ts(slot: &mut Option<i64>, value: Option<i64>) {
     if let Some(ts) = value {
         *slot = Some(slot.map_or(ts, |current| current.min(ts)));
@@ -381,6 +535,7 @@ fn parse_fit_bytes(file_name: &str, bytes: &[u8]) -> Result<ParsedActivity> {
     let mut activity_total_timer_time_s: Option<f64> = None;
     let mut lap_total_timer_time_sum_s: Option<f64> = None;
     let mut lap_ranges: Vec<serde_json::Value> = Vec::new();
+    let mut timer_events: Vec<TimerEvent> = Vec::new();
     let mut heart_rate_zone_bounds_bpm: Vec<i64> = Vec::new();
 
     let mut min_ts: Option<i64> = None;
@@ -589,6 +744,32 @@ fn parse_fit_bytes(file_name: &str, bytes: &[u8]) -> Result<ParsedActivity> {
                     activity_total_timer_time_s = value_f64(field.value());
                 }
             }
+        } else if rec.kind() == MesgNum::Event {
+            let mut timestamp_ms: Option<i64> = None;
+            let mut event: Option<String> = None;
+            let mut event_type: Option<String> = None;
+            let mut timer_trigger: Option<String> = None;
+
+            for field in rec.fields() {
+                match field.name() {
+                    "timestamp" => timestamp_ms = value_timestamp_ms(field.value()),
+                    "event" => event = fit_event_name(field.value()),
+                    "event_type" => event_type = fit_event_type_name(field.value()),
+                    "timer_trigger" => timer_trigger = fit_timer_trigger_name(field.value()),
+                    _ => {}
+                }
+            }
+
+            if event.as_deref() == Some("timer") {
+                if let (Some(timestamp_ms), Some(event_type)) = (timestamp_ms, event_type) {
+                    timer_events.push(TimerEvent {
+                        timestamp_ms,
+                        event: "timer".to_string(),
+                        event_type,
+                        timer_trigger,
+                    });
+                }
+            }
         } else if rec.kind() == MesgNum::Lap {
             let mut lap_start_ms: Option<i64> = None;
             let mut lap_end_ms: Option<i64> = None;
@@ -730,6 +911,13 @@ fn parse_fit_bytes(file_name: &str, bytes: &[u8]) -> Result<ParsedActivity> {
     );
     let distance_m = total_distance_m(&points);
     let (start_latitude, start_longitude) = first_valid_coordinates(&points);
+    let timer_metadata = build_timer_metadata(
+        &timer_events,
+        record_start_ts,
+        record_end_ts,
+        session_total_elapsed_time_sum_s,
+        duration_s,
+    );
 
     let file_id_combined_name = combine_device_name(
         file_id_product_name.clone(),
@@ -776,6 +964,7 @@ fn parse_fit_bytes(file_name: &str, bytes: &[u8]) -> Result<ParsedActivity> {
         "activity": {
             "total_timer_time_s": activity_total_timer_time_s
         },
+        "timer": timer_metadata,
         "heart_rate_zone_bounds_bpm": heart_rate_zone_bounds_bpm,
         "session": {
             "count": session_count,
@@ -1198,6 +1387,74 @@ mod tests {
 
         assert_eq!(duration, 2_705.309);
         assert_eq!(source, "sessions.total_elapsed_time_sum");
+    }
+
+    fn timer_event(timestamp_ms: i64, event_type: &str, trigger: Option<&str>) -> TimerEvent {
+        TimerEvent {
+            timestamp_ms,
+            event: "timer".to_string(),
+            event_type: event_type.to_string(),
+            timer_trigger: trigger.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn fit_timer_intervals_pair_stop_with_next_start() {
+        let events = vec![
+            timer_event(0, "start", Some("manual")),
+            timer_event(10_000, "stop_all", Some("auto")),
+            timer_event(20_000, "start", Some("auto")),
+            timer_event(30_000, "stop_all", Some("manual")),
+        ];
+
+        let intervals = build_stopped_intervals(&events, 0, 40_000);
+
+        assert_eq!(intervals.len(), 1);
+        assert_eq!(intervals[0].start_ms, 10_000);
+        assert_eq!(intervals[0].end_ms, 20_000);
+        assert_eq!(intervals[0].trigger.as_deref(), Some("auto"));
+        assert_eq!(intervals[0].resume_trigger.as_deref(), Some("auto"));
+    }
+
+    #[test]
+    fn fit_timer_intervals_clamp_to_record_bounds() {
+        let events = vec![
+            timer_event(5_000, "stop", Some("manual")),
+            timer_event(20_000, "start", Some("manual")),
+        ];
+
+        let intervals = build_stopped_intervals(&events, 10_000, 15_000);
+
+        assert_eq!(intervals.len(), 1);
+        assert_eq!(intervals[0].start_ms, 10_000);
+        assert_eq!(intervals[0].end_ms, 15_000);
+    }
+
+    #[test]
+    fn fit_timer_metadata_marks_reliable_when_active_time_matches_timer() {
+        let events = vec![
+            timer_event(10_000, "stop_all", Some("auto")),
+            timer_event(20_000, "start", Some("auto")),
+        ];
+
+        let metadata = build_timer_metadata(&events, 0, 100_000, Some(100.0), 90.0);
+
+        assert_eq!(metadata["active_time_supported"].as_bool(), Some(true));
+        assert_eq!(metadata["intervals_reliable"].as_bool(), Some(true));
+        assert_eq!(metadata["stopped_time_s"].as_f64(), Some(10.0));
+    }
+
+    #[test]
+    fn fit_timer_metadata_falls_back_when_intervals_do_not_match_timer() {
+        let events = vec![
+            timer_event(10_000, "stop_all", Some("auto")),
+            timer_event(20_000, "start", Some("auto")),
+        ];
+
+        let metadata = build_timer_metadata(&events, 0, 100_000, Some(100.0), 70.0);
+
+        assert_eq!(metadata["active_time_supported"].as_bool(), Some(false));
+        assert_eq!(metadata["intervals_reliable"].as_bool(), Some(false));
     }
 
     #[test]

--- a/src/components/ActivityChart.tsx
+++ b/src/components/ActivityChart.tsx
@@ -3,13 +3,21 @@ import type { RecordPoint } from "../types";
 import { enableChartWheelPageScroll } from "../lib/chartScroll";
 import { buildHeartRateZones } from "../lib/hrZones";
 import { applyRollingAverageSeries, getDynamicSmoothingWindow } from "../lib/chartSmoothing";
-import { convertDistanceMeters, convertPaceMinPerKm, distanceLabel, paceLabel, type DistanceUnit } from "../lib/units";
+import { convertPaceMinPerKm, paceLabel, type DistanceUnit } from "../lib/units";
+import {
+  buildLapMarkers,
+  buildTelemetryPoints,
+  formatTelemetryTooltipHeader,
+  formatTelemetryXAxisTick,
+  type TelemetryXAxisMode,
+} from "../lib/telemetryAxis";
 import { useTranslation } from "../lib/i18n";
 
 type Props = {
   records: RecordPoint[];
   theme: "light" | "dark";
   distanceUnit: DistanceUnit;
+  xAxisMode?: TelemetryXAxisMode;
   heartRateZoneBoundsBpm?: number[];
   zoomRange?: { start: number; end: number } | null;
   onZoomChange?: (range: { start: number; end: number }) => void;
@@ -17,10 +25,17 @@ type Props = {
   smoothGraphs?: boolean;
 };
 
+type SeriesRow = [number, number | null, number, number, number | null];
+
+function isSeriesRow(row: [number | null, number | null, number, number, number | null]): row is SeriesRow {
+  return typeof row[0] === "number" && Number.isFinite(row[0]);
+}
+
 export function ActivityChart({
   records,
   theme,
   distanceUnit,
+  xAxisMode = "time",
   heartRateZoneBoundsBpm,
   zoomRange,
   onZoomChange,
@@ -31,59 +46,35 @@ export function ActivityChart({
   const totalDurationMs = Math.max(0, (records[records.length - 1]?.timestamp_ms ?? t0) - t0);
   const smoothWindow = smoothGraphs ? getDynamicSmoothingWindow(records.length, totalDurationMs, zoomRange) : 1;
   const { t } = useTranslation();
-  
-  // Format MM:SS or HH:MM:SS
-  const formatRelTime = (ms: number) => {
-    const totalSec = Math.floor(Math.max(0, ms) / 1000);
-    const h = Math.floor(totalSec / 3600);
-    const m = Math.floor((totalSec % 3600) / 60);
-    const s = totalSec % 60;
-    if (h > 0) {
-      return `${h}:${m.toString().padStart(2, "0")}:${s.toString().padStart(2, "0")}`;
-    }
-    return `${m}:${s.toString().padStart(2, "0")}`;
-  };
 
-  const formatAbsTime = (relMs: number) => {
-    const absolute = new Date(t0 + Math.max(0, relMs));
-    const hh = String(absolute.getHours()).padStart(2, "0");
-    const mm = String(absolute.getMinutes()).padStart(2, "0");
-    const ss = String(absolute.getSeconds()).padStart(2, "0");
-    return `${hh}:${mm}:${ss}`;
-  };
-
-  const formatTooltipHeader = (relMs: number) =>
-    `<div style="display:flex;align-items:center;gap:6px;"><strong>${formatRelTime(relMs)}</strong><span style="display:inline-flex;align-items:center;border-radius:999px;padding:1px 6px;font-size:11px;background:rgba(148,163,184,0.22);">${formatAbsTime(relMs)}</span></div>`;
+  const telemetryPoints = buildTelemetryPoints(records, t0, xAxisMode, distanceUnit);
+  const formatTooltipHeader = (relMs: number, distanceMeters: number | null) =>
+    formatTelemetryTooltipHeader(xAxisMode, t0, relMs, distanceMeters, distanceUnit);
 
   const hrZones = buildHeartRateZones(heartRateZoneBoundsBpm);
-  const hrSeriesData = records.map((r) => [r.timestamp_ms - t0, r.heart_rate ?? null, r.timestamp_ms, typeof r.distance_m === "number" ? r.distance_m / 1000 : null]);
-  const paceSeriesData = records.map((r, i) => {
-    const relMs = r.timestamp_ms - t0;
-    const prev = i > 0 ? records[i - 1] : undefined;
-    const dtS = prev ? (r.timestamp_ms - prev.timestamp_ms) / 1000 : 0;
-    const derivedSpeed =
-      (!r.speed_m_s && prev && typeof r.distance_m === "number" && typeof prev.distance_m === "number" && dtS > 0)
-        ? Math.max(0, (r.distance_m - prev.distance_m) / dtS)
-        : undefined;
-    const speedMs = r.speed_m_s ?? derivedSpeed;
-    const paceMinPerKm = speedMs && speedMs > 0 ? 1000 / (speedMs * 60) : null;
-    const paceMinPerUnit = paceMinPerKm == null ? null : convertPaceMinPerKm(paceMinPerKm, distanceUnit);
-    return [relMs, paceMinPerUnit, r.timestamp_ms];
-  });
+  const hrSeriesData = telemetryPoints
+    .map((point, i) => [point.x, records[i].heart_rate ?? null, point.relMs, point.timestampMs, point.distanceMeters] as [number | null, number | null, number, number, number | null])
+    .filter(isSeriesRow);
+  const paceSeriesData = telemetryPoints
+    .map((point, i) => {
+      const record = records[i];
+      const prev = i > 0 ? records[i - 1] : undefined;
+      const dtS = prev ? (record.timestamp_ms - prev.timestamp_ms) / 1000 : 0;
+      const derivedSpeed =
+        (!record.speed_m_s && prev && typeof record.distance_m === "number" && typeof prev.distance_m === "number" && dtS > 0)
+          ? Math.max(0, (record.distance_m - prev.distance_m) / dtS)
+          : undefined;
+      const speedMs = record.speed_m_s ?? derivedSpeed;
+      const paceMinPerKm = speedMs && speedMs > 0 ? 1000 / (speedMs * 60) : null;
+      const paceMinPerUnit = paceMinPerKm == null ? null : convertPaceMinPerKm(paceMinPerKm, distanceUnit);
+      return [point.x, paceMinPerUnit, point.relMs, point.timestampMs, point.distanceMeters] as [number | null, number | null, number, number, number | null];
+    })
+    .filter(isSeriesRow);
 
   const hrSeriesSmoothed = smoothGraphs ? applyRollingAverageSeries(hrSeriesData, 1, smoothWindow) : hrSeriesData;
   const paceSeriesSmoothed = smoothGraphs ? applyRollingAverageSeries(paceSeriesData, 1, smoothWindow) : paceSeriesData;
 
-  const lapMarkers = lapTimestampsUtc
-    .slice(1)
-    .map((ts, idx) => {
-      const parsed = Date.parse(ts);
-      if (!Number.isFinite(parsed)) return null;
-      const relMs = parsed - t0;
-      if (relMs < 0) return null;
-      return { xAxis: relMs, name: `Lap ${idx + 1}` };
-    })
-    .filter((m): m is { xAxis: number; name: string } => m !== null);
+  const lapMarkers = buildLapMarkers(records, lapTimestampsUtc, t0, xAxisMode, distanceUnit);
 
   const isDark = theme === "dark";
   const axisColor = isDark ? "#8899b8" : "#64748b";
@@ -91,6 +82,17 @@ export function ActivityChart({
   const tooltipBg = isDark ? "rgba(14, 22, 45, 0.95)" : "rgba(255, 255, 255, 0.95)";
   const tooltipBorder = isDark ? "rgba(100, 140, 220, 0.2)" : "rgba(0, 0, 0, 0.08)";
   const tooltipText = isDark ? "#e2e8f4" : "#0f172a";
+
+  const sharedXAxis = {
+    type: "value",
+    axisLabel: {
+      color: axisColor,
+      fontSize: 11,
+      formatter: (val: number) => formatTelemetryXAxisTick(val, xAxisMode, distanceUnit),
+    },
+    axisLine: { lineStyle: { color: gridLine } },
+    splitLine: { show: false },
+  };
 
   const hrOption = {
     tooltip: {
@@ -100,17 +102,13 @@ export function ActivityChart({
       textStyle: { color: tooltipText, fontSize: 12 },
       formatter: (params: any) => {
         const p = params[0];
-        const relTime = Number(p.value[0] ?? 0);
-        let html = formatTooltipHeader(relTime);
+        const relTime = Number(p.value[2] ?? 0);
+        const distanceMeters = p?.value?.[4] as number | null | undefined;
+        let html = formatTooltipHeader(relTime, distanceMeters ?? null);
         for (const s of params) {
           if (s.value[1] !== null && s.value[1] !== undefined) {
             html += `<div>${s.marker} ${s.seriesName}: <strong>${s.value[1]}</strong></div>`;
           }
-        }
-        const distanceKm = p?.value?.[3] as number | null | undefined;
-        if (distanceKm !== null && distanceKm !== undefined) {
-          const distanceInUnit = convertDistanceMeters(Number(distanceKm) * 1000, distanceUnit);
-          html += `<div style="margin-top:2px;">${t("chart.distance")}: <strong>${distanceInUnit.toFixed(2)} ${distanceLabel(distanceUnit)}</strong></div>`;
         }
         return html;
       }
@@ -135,16 +133,7 @@ export function ActivityChart({
       }),
     },
     grid: { left: 48, right: 16, top: 36, bottom: 38 },
-    xAxis: {
-      type: "value",
-      axisLabel: {
-        color: axisColor,
-        fontSize: 11,
-        formatter: (val: number) => formatRelTime(val)
-      },
-      axisLine: { lineStyle: { color: gridLine } },
-      splitLine: { show: false },
-    },
+    xAxis: sharedXAxis,
     yAxis: {
       type: "value",
       name: "bpm",
@@ -191,8 +180,9 @@ export function ActivityChart({
       textStyle: { color: tooltipText, fontSize: 12 },
       formatter: (params: any) => {
         const p = params[0];
-        const relTime = Number(p.value[0] ?? 0);
-        let html = formatTooltipHeader(relTime);
+        const relTime = Number(p.value[2] ?? 0);
+        const distanceMeters = p?.value?.[4] as number | null | undefined;
+        let html = formatTooltipHeader(relTime, distanceMeters ?? null);
         for (const s of params) {
           if (s.value[1] !== null && s.value[1] !== undefined) {
             const pace = Number(s.value[1]);
@@ -210,16 +200,7 @@ export function ActivityChart({
       top: 0,
     },
     grid: { left: 48, right: 16, top: 36, bottom: 38 },
-    xAxis: {
-      type: "value",
-      axisLabel: {
-        color: axisColor,
-        fontSize: 11,
-        formatter: (val: number) => formatRelTime(val)
-      },
-      axisLine: { lineStyle: { color: gridLine } },
-      splitLine: { show: false },
-    },
+    xAxis: sharedXAxis,
     yAxis: {
       type: "value",
       name: paceLabel(distanceUnit),

--- a/src/components/ActivityChart.tsx
+++ b/src/components/ActivityChart.tsx
@@ -10,6 +10,7 @@ import {
   buildTelemetryXAxisBounds,
   formatTelemetryTooltipHeader,
   formatTelemetryXAxisTick,
+  type TelemetryTimerMetadata,
   type TelemetryXAxisMode,
 } from "../lib/telemetryAxis";
 import { useTranslation } from "../lib/i18n";
@@ -24,6 +25,7 @@ type Props = {
   onZoomChange?: (range: { start: number; end: number }) => void;
   lapTimestampsUtc?: string[];
   smoothGraphs?: boolean;
+  timerMetadata?: TelemetryTimerMetadata | null;
 };
 
 type SeriesRow = [number, number | null, number, number, number | null];
@@ -42,29 +44,31 @@ export function ActivityChart({
   onZoomChange,
   lapTimestampsUtc = [],
   smoothGraphs = true,
+  timerMetadata,
 }: Props) {
   const t0 = records[0]?.timestamp_ms ?? 0;
-  const totalDurationMs = Math.max(0, (records[records.length - 1]?.timestamp_ms ?? t0) - t0);
-  const smoothWindow = smoothGraphs ? getDynamicSmoothingWindow(records.length, totalDurationMs, zoomRange) : 1;
   const { t } = useTranslation();
 
-  const telemetryPoints = buildTelemetryPoints(records, t0, xAxisMode, distanceUnit);
+  const telemetryPoints = buildTelemetryPoints(records, t0, xAxisMode, distanceUnit, timerMetadata);
+  const totalDurationMs = Math.max(0, telemetryPoints[telemetryPoints.length - 1]?.relMs ?? ((records[records.length - 1]?.timestamp_ms ?? t0) - t0));
+  const smoothWindow = smoothGraphs ? getDynamicSmoothingWindow(telemetryPoints.length || records.length, totalDurationMs, zoomRange) : 1;
   const xAxisBounds = buildTelemetryXAxisBounds(telemetryPoints);
-  const formatTooltipHeader = (relMs: number, distanceMeters: number | null) =>
-    formatTelemetryTooltipHeader(xAxisMode, t0, relMs, distanceMeters, distanceUnit);
+  const formatTooltipHeader = (relMs: number, distanceMeters: number | null, timestampMs?: number) =>
+    formatTelemetryTooltipHeader(xAxisMode, t0, relMs, distanceMeters, distanceUnit, timestampMs);
 
   const hrZones = buildHeartRateZones(heartRateZoneBoundsBpm);
   const hrSeriesData = telemetryPoints
-    .map((point, i) => [point.x, records[i].heart_rate ?? null, point.relMs, point.timestampMs, point.distanceMeters] as [number | null, number | null, number, number, number | null])
+    .map((point) => [point.x, point.record.heart_rate ?? null, point.relMs, point.timestampMs, point.distanceMeters] as [number | null, number | null, number, number, number | null])
     .filter(isSeriesRow);
   const paceSeriesData = telemetryPoints
     .map((point, i) => {
-      const record = records[i];
-      const prev = i > 0 ? records[i - 1] : undefined;
-      const dtS = prev ? (record.timestamp_ms - prev.timestamp_ms) / 1000 : 0;
+      const record = point.record;
+      const prevPoint = i > 0 ? telemetryPoints[i - 1] : undefined;
+      const prevRecord = prevPoint?.record;
+      const dtS = prevPoint ? (point.relMs - prevPoint.relMs) / 1000 : 0;
       const derivedSpeed =
-        (!record.speed_m_s && prev && typeof record.distance_m === "number" && typeof prev.distance_m === "number" && dtS > 0)
-          ? Math.max(0, (record.distance_m - prev.distance_m) / dtS)
+        (!record.speed_m_s && prevRecord && typeof record.distance_m === "number" && typeof prevRecord.distance_m === "number" && dtS > 0)
+          ? Math.max(0, (record.distance_m - prevRecord.distance_m) / dtS)
           : undefined;
       const speedMs = record.speed_m_s ?? derivedSpeed;
       const paceMinPerKm = speedMs && speedMs > 0 ? 1000 / (speedMs * 60) : null;
@@ -76,7 +80,7 @@ export function ActivityChart({
   const hrSeriesSmoothed = smoothGraphs ? applyRollingAverageSeries(hrSeriesData, 1, smoothWindow) : hrSeriesData;
   const paceSeriesSmoothed = smoothGraphs ? applyRollingAverageSeries(paceSeriesData, 1, smoothWindow) : paceSeriesData;
 
-  const lapMarkers = buildLapMarkers(records, lapTimestampsUtc, t0, xAxisMode, distanceUnit);
+  const lapMarkers = buildLapMarkers(records, lapTimestampsUtc, t0, xAxisMode, distanceUnit, timerMetadata);
 
   const isDark = theme === "dark";
   const axisColor = isDark ? "#8899b8" : "#64748b";
@@ -107,7 +111,7 @@ export function ActivityChart({
         const p = params[0];
         const relTime = Number(p.value[2] ?? 0);
         const distanceMeters = p?.value?.[4] as number | null | undefined;
-        let html = formatTooltipHeader(relTime, distanceMeters ?? null);
+        let html = formatTooltipHeader(relTime, distanceMeters ?? null, Number(p.value[3] ?? 0));
         for (const s of params) {
           if (s.value[1] !== null && s.value[1] !== undefined) {
             html += `<div>${s.marker} ${s.seriesName}: <strong>${s.value[1]}</strong></div>`;
@@ -185,7 +189,7 @@ export function ActivityChart({
         const p = params[0];
         const relTime = Number(p.value[2] ?? 0);
         const distanceMeters = p?.value?.[4] as number | null | undefined;
-        let html = formatTooltipHeader(relTime, distanceMeters ?? null);
+        let html = formatTooltipHeader(relTime, distanceMeters ?? null, Number(p.value[3] ?? 0));
         for (const s of params) {
           if (s.value[1] !== null && s.value[1] !== undefined) {
             const pace = Number(s.value[1]);

--- a/src/components/ActivityChart.tsx
+++ b/src/components/ActivityChart.tsx
@@ -7,6 +7,7 @@ import { convertPaceMinPerKm, paceLabel, type DistanceUnit } from "../lib/units"
 import {
   buildLapMarkers,
   buildTelemetryPoints,
+  buildTelemetryXAxisBounds,
   formatTelemetryTooltipHeader,
   formatTelemetryXAxisTick,
   type TelemetryXAxisMode,
@@ -48,6 +49,7 @@ export function ActivityChart({
   const { t } = useTranslation();
 
   const telemetryPoints = buildTelemetryPoints(records, t0, xAxisMode, distanceUnit);
+  const xAxisBounds = buildTelemetryXAxisBounds(telemetryPoints);
   const formatTooltipHeader = (relMs: number, distanceMeters: number | null) =>
     formatTelemetryTooltipHeader(xAxisMode, t0, relMs, distanceMeters, distanceUnit);
 
@@ -85,6 +87,7 @@ export function ActivityChart({
 
   const sharedXAxis = {
     type: "value",
+    ...xAxisBounds,
     axisLabel: {
       color: axisColor,
       fontSize: 11,

--- a/src/components/ActivityInsights.tsx
+++ b/src/components/ActivityInsights.tsx
@@ -17,6 +17,7 @@ import {
   formatRelTime,
   formatTelemetryTooltipHeader,
   formatTelemetryXAxisTick,
+  type TelemetryTimerMetadata,
   type TelemetryXAxisMode,
 } from "../lib/telemetryAxis";
 import { useTranslation } from "../lib/i18n";
@@ -31,6 +32,7 @@ type Props = {
   onZoomChange?: (range: { start: number; end: number }) => void;
   lapTimestampsUtc?: string[];
   smoothGraphs?: boolean;
+  timerMetadata?: TelemetryTimerMetadata | null;
 };
 
 type SeriesRow = [number, number | null, number, number, number | null];
@@ -55,6 +57,7 @@ export function ActivityInsights({
   onZoomChange,
   lapTimestampsUtc = [],
   smoothGraphs = true,
+  timerMetadata,
 }: Props) {
   const hrZones = buildHeartRateZones(heartRateZoneBoundsBpm);
   const isDark = theme === "dark";
@@ -81,24 +84,25 @@ export function ActivityInsights({
   }
 
   const t0 = records[0]?.timestamp_ms ?? 0;
-  const totalDurationMs = Math.max(0, (records[records.length - 1]?.timestamp_ms ?? t0) - t0);
-  const smoothWindow = smoothGraphs ? getDynamicSmoothingWindow(records.length, totalDurationMs, zoomRange) : 1;
-  const telemetryPoints = buildTelemetryPoints(records, t0, xAxisMode, distanceUnit);
+  const telemetryPoints = buildTelemetryPoints(records, t0, xAxisMode, distanceUnit, timerMetadata);
+  const totalDurationMs = Math.max(0, telemetryPoints[telemetryPoints.length - 1]?.relMs ?? ((records[records.length - 1]?.timestamp_ms ?? t0) - t0));
+  const smoothWindow = smoothGraphs ? getDynamicSmoothingWindow(telemetryPoints.length || records.length, totalDurationMs, zoomRange) : 1;
   const xAxisBounds = buildTelemetryXAxisBounds(telemetryPoints);
-  const formatTooltipHeader = (relMs: number, distanceMeters: number | null, mode: TelemetryXAxisMode = xAxisMode) =>
-    formatTelemetryTooltipHeader(mode, t0, relMs, distanceMeters, distanceUnit);
+  const formatTooltipHeader = (relMs: number, distanceMeters: number | null, mode: TelemetryXAxisMode = xAxisMode, timestampMs?: number) =>
+    formatTelemetryTooltipHeader(mode, t0, relMs, distanceMeters, distanceUnit, timestampMs);
 
-  const timeline = records.map((r, i) => {
-    const prev = i > 0 ? records[i - 1] : undefined;
-    const dt = prev ? (r.timestamp_ms - prev.timestamp_ms) / 1000 : 0;
+  const timeline = telemetryPoints.map((point, i) => {
+    const r = point.record;
+    const prevPoint = i > 0 ? telemetryPoints[i - 1] : undefined;
+    const prevRecord = prevPoint?.record;
+    const dt = prevPoint ? (point.relMs - prevPoint.relMs) / 1000 : 0;
     const derivedSpeed =
-      !r.speed_m_s && prev && typeof r.distance_m === "number" && typeof prev.distance_m === "number" && dt > 0
-        ? Math.max(0, (r.distance_m - prev.distance_m) / dt)
+      !r.speed_m_s && prevRecord && typeof r.distance_m === "number" && typeof prevRecord.distance_m === "number" && dt > 0
+        ? Math.max(0, (r.distance_m - prevRecord.distance_m) / dt)
         : undefined;
     const speedMs = r.speed_m_s ?? derivedSpeed;
     const speedInUnit = typeof speedMs === "number" ? convertSpeedMps(speedMs, distanceUnit) : null;
     const paceMinPerUnit = speedInUnit && speedInUnit > 0 ? 60 / speedInUnit : null;
-    const point = telemetryPoints[i];
     return {
       x: point.x,
       relMs: point.relMs,
@@ -110,7 +114,7 @@ export function ActivityInsights({
       power: r.power ?? null,
       cadence: r.cadence ?? null,
       temperatureC: r.temperature_c ?? null,
-      timestampMs: r.timestamp_ms,
+      timestampMs: point.timestampMs,
     };
   });
 
@@ -124,20 +128,20 @@ export function ActivityInsights({
   const cadenceLineDataSmoothed = smoothGraphs ? applyRollingAverageSeries(cadenceLineData, 1, smoothWindow) : cadenceLineData;
   const powerLineDataSmoothed = smoothGraphs ? applyRollingAverageSeries(powerLineData, 1, smoothWindow) : powerLineData;
 
-  const hasPowerData = records.some((r) => typeof r.power === "number" && r.power > 0);
-  const hasHeartRateData = records.some((r) => typeof r.heart_rate === "number" && r.heart_rate > 0);
+  const hasPowerData = timeline.some((d) => typeof d.power === "number" && d.power > 0);
+  const hasHeartRateData = timeline.some((d) => typeof d.heartRate === "number" && d.heartRate > 0);
 
-  const lapMarkers = buildLapMarkers(records, lapTimestampsUtc, t0, xAxisMode, distanceUnit);
+  const lapMarkers = buildLapMarkers(records, lapTimestampsUtc, t0, xAxisMode, distanceUnit, timerMetadata);
 
-  const hrValues = records
-    .map((r) => r.heart_rate)
+  const hrValues = timeline
+    .map((d) => d.heartRate)
     .filter((n): n is number => typeof n === "number" && n > 0);
   const zoneMinutes = hrZones.map(() => 0);
   if (hrValues.length > 0) {
-    for (let i = 0; i < records.length - 1; i += 1) {
-      const hr = records[i].heart_rate;
+    for (let i = 0; i < timeline.length - 1; i += 1) {
+      const hr = timeline[i].heartRate;
       if (typeof hr !== "number" || hr <= 0) continue;
-      const dtMin = Math.max(0, (records[i + 1].timestamp_ms - records[i].timestamp_ms) / 60000);
+      const dtMin = Math.max(0, (timeline[i + 1].relMs - timeline[i].relMs) / 60000);
       const zoneIndex = resolveHeartRateZoneIndex(hr, hrZones);
       zoneMinutes[zoneIndex] += dtMin;
     }
@@ -159,7 +163,7 @@ export function ActivityInsights({
         const p = params?.[0];
         const rel = Number(p?.value?.[2] ?? 0);
         const distanceMeters = (p?.value?.[4] ?? null) as number | null;
-        let html = formatTooltipHeader(rel, distanceMeters);
+        let html = formatTooltipHeader(rel, distanceMeters, xAxisMode, Number(p?.value?.[3] ?? 0));
         for (const row of params) {
           if (row.value?.[1] !== null && row.value?.[1] !== undefined) {
             html += `<div>${row.marker} ${row.seriesName}: <strong>${Number(row.value[1]).toFixed(2)}</strong></div>`;
@@ -213,7 +217,7 @@ export function ActivityInsights({
         const rel = Number(p?.value?.[2] ?? 0);
         const distanceMeters = (p?.value?.[4] ?? null) as number | null;
         const val = p?.value?.[1];
-        return `${formatTooltipHeader(rel, distanceMeters)}<div>${p?.marker ?? ""} ${tr("insights.elevation")}: <strong>${val == null ? "--" : Number(val).toFixed(2)} ${elevationLabel(distanceUnit)}</strong></div>`;
+        return `${formatTooltipHeader(rel, distanceMeters, xAxisMode, Number(p?.value?.[3] ?? 0))}<div>${p?.marker ?? ""} ${tr("insights.elevation")}: <strong>${val == null ? "--" : Number(val).toFixed(2)} ${elevationLabel(distanceUnit)}</strong></div>`;
       }
     },
     legend: { textStyle: { color: axisColor, fontSize: 12 }, top: 0 },
@@ -286,7 +290,7 @@ export function ActivityInsights({
         const p = params?.[0];
         const rel = Number(p?.value?.[2] ?? 0);
         const distanceMeters = (p?.value?.[4] ?? null) as number | null;
-        let html = formatTooltipHeader(rel, distanceMeters);
+        let html = formatTooltipHeader(rel, distanceMeters, xAxisMode, Number(p?.value?.[3] ?? 0));
         for (const row of params) {
           if (row.value?.[1] !== null && row.value?.[1] !== undefined) {
             const unit = row.seriesName === tr("insights.cadence") ? " rpm" : " W";
@@ -345,9 +349,9 @@ export function ActivityInsights({
     ],
   };
 
-  const hrPowerScatter = records
-    .filter((r) => typeof r.heart_rate === "number" && typeof r.power === "number")
-    .map((r) => [r.heart_rate as number, r.power as number]);
+  const hrPowerScatter = timeline
+    .filter((d) => typeof d.heartRate === "number" && typeof d.power === "number")
+    .map((d) => [d.heartRate as number, d.power as number]);
 
   const scatterOption = {
     tooltip: { trigger: "item", ...tooltipStyle },
@@ -452,7 +456,7 @@ export function ActivityInsights({
     ],
   };
 
-  const totalRelMs = Math.max(0, (records[records.length - 1]?.timestamp_ms ?? t0) - t0);
+  const totalRelMs = Math.max(0, timeline[timeline.length - 1]?.relMs ?? totalDurationMs);
   const heatBins = Math.max(1, Math.ceil(totalRelMs / 60000));
   const heatMetrics = [
     {

--- a/src/components/ActivityInsights.tsx
+++ b/src/components/ActivityInsights.tsx
@@ -10,12 +10,21 @@ import {
   speedLabel,
   type DistanceUnit,
 } from "../lib/units";
+import {
+  buildLapMarkers,
+  buildTelemetryPoints,
+  formatRelTime,
+  formatTelemetryTooltipHeader,
+  formatTelemetryXAxisTick,
+  type TelemetryXAxisMode,
+} from "../lib/telemetryAxis";
 import { useTranslation } from "../lib/i18n";
 
 type Props = {
   records: RecordPoint[];
   theme: "light" | "dark";
   distanceUnit: DistanceUnit;
+  xAxisMode?: TelemetryXAxisMode;
   heartRateZoneBoundsBpm?: number[];
   zoomRange?: { start: number; end: number } | null;
   onZoomChange?: (range: { start: number; end: number }) => void;
@@ -23,42 +32,30 @@ type Props = {
   smoothGraphs?: boolean;
 };
 
+type SeriesRow = [number, number | null, number, number, number | null];
+
+function isSeriesRow(row: [number | null, number | null, number, number, number | null]): row is SeriesRow {
+  return typeof row[0] === "number" && Number.isFinite(row[0]);
+}
+
 function safeAvg(values: Array<number | null | undefined>): number | null {
   const nums = values.filter((v): v is number => typeof v === "number" && Number.isFinite(v));
   if (!nums.length) return null;
   return nums.reduce((sum, n) => sum + n, 0) / nums.length;
 }
 
-function formatRelTime(ms: number): string {
-  const totalSec = Math.floor(Math.max(0, ms) / 1000);
-  const h = Math.floor(totalSec / 3600);
-  const m = Math.floor((totalSec % 3600) / 60);
-  const s = totalSec % 60;
-  if (h > 0) {
-    return `${h}:${m.toString().padStart(2, "0")}:${s.toString().padStart(2, "0")}`;
-  }
-  return `${m}:${s.toString().padStart(2, "0")}`;
-}
-
-function formatAbsTime(baseTimestampMs: number, relMs: number): string {
-  const absolute = new Date(baseTimestampMs + Math.max(0, relMs));
-  const hh = String(absolute.getHours()).padStart(2, "0");
-  const mm = String(absolute.getMinutes()).padStart(2, "0");
-  const ss = String(absolute.getSeconds()).padStart(2, "0");
-  return `${hh}:${mm}:${ss}`;
-}
-
 export function ActivityInsights({
   records,
   theme,
   distanceUnit,
+  xAxisMode = "time",
   heartRateZoneBoundsBpm,
   zoomRange,
   onZoomChange,
   lapTimestampsUtc = [],
   smoothGraphs = true,
 }: Props) {
-    const hrZones = buildHeartRateZones(heartRateZoneBoundsBpm);
+  const hrZones = buildHeartRateZones(heartRateZoneBoundsBpm);
   const isDark = theme === "dark";
   const { t: tr } = useTranslation();
   const axisColor = isDark ? "#8899b8" : "#64748b";
@@ -72,8 +69,6 @@ export function ActivityInsights({
     borderColor: tooltipBorder,
     textStyle: { color: tooltipText, fontSize: 12 },
   };
-  const formatTooltipHeader = (relMs: number) =>
-    `<div style="display:flex;align-items:center;gap:6px;"><strong>${formatRelTime(relMs)}</strong><span style="display:inline-flex;align-items:center;border-radius:999px;padding:1px 6px;font-size:11px;background:rgba(148,163,184,0.22);">${formatAbsTime(t0, relMs)}</span></div>`;
 
   if (!records.length) {
     return (
@@ -87,6 +82,10 @@ export function ActivityInsights({
   const t0 = records[0]?.timestamp_ms ?? 0;
   const totalDurationMs = Math.max(0, (records[records.length - 1]?.timestamp_ms ?? t0) - t0);
   const smoothWindow = smoothGraphs ? getDynamicSmoothingWindow(records.length, totalDurationMs, zoomRange) : 1;
+  const telemetryPoints = buildTelemetryPoints(records, t0, xAxisMode, distanceUnit);
+  const formatTooltipHeader = (relMs: number, distanceMeters: number | null, mode: TelemetryXAxisMode = xAxisMode) =>
+    formatTelemetryTooltipHeader(mode, t0, relMs, distanceMeters, distanceUnit);
+
   const timeline = records.map((r, i) => {
     const prev = i > 0 ? records[i - 1] : undefined;
     const dt = prev ? (r.timestamp_ms - prev.timestamp_ms) / 1000 : 0;
@@ -97,8 +96,11 @@ export function ActivityInsights({
     const speedMs = r.speed_m_s ?? derivedSpeed;
     const speedInUnit = typeof speedMs === "number" ? convertSpeedMps(speedMs, distanceUnit) : null;
     const paceMinPerUnit = speedInUnit && speedInUnit > 0 ? 60 / speedInUnit : null;
+    const point = telemetryPoints[i];
     return {
-      relMs: r.timestamp_ms - t0,
+      x: point.x,
+      relMs: point.relMs,
+      distanceMeters: point.distanceMeters,
       speedInUnit,
       altitudeInUnit: typeof r.altitude_m === "number" ? convertElevationMeters(r.altitude_m, distanceUnit) : null,
       paceMinPerUnit,
@@ -110,10 +112,10 @@ export function ActivityInsights({
     };
   });
 
-  const speedLineData = timeline.map((d) => [d.relMs, d.speedInUnit]);
-  const elevationLineData = timeline.map((d) => [d.relMs, d.altitudeInUnit]);
-  const cadenceLineData = timeline.map((d) => [d.relMs, d.cadence]);
-  const powerLineData = timeline.map((d) => [d.relMs, d.power]);
+  const speedLineData = timeline.map((d) => [d.x, d.speedInUnit, d.relMs, d.timestampMs, d.distanceMeters] as [number | null, number | null, number, number, number | null]).filter(isSeriesRow);
+  const elevationLineData = timeline.map((d) => [d.x, d.altitudeInUnit, d.relMs, d.timestampMs, d.distanceMeters] as [number | null, number | null, number, number, number | null]).filter(isSeriesRow);
+  const cadenceLineData = timeline.map((d) => [d.x, d.cadence, d.relMs, d.timestampMs, d.distanceMeters] as [number | null, number | null, number, number, number | null]).filter(isSeriesRow);
+  const powerLineData = timeline.map((d) => [d.x, d.power, d.relMs, d.timestampMs, d.distanceMeters] as [number | null, number | null, number, number, number | null]).filter(isSeriesRow);
 
   const speedLineDataSmoothed = smoothGraphs ? applyRollingAverageSeries(speedLineData, 1, smoothWindow) : speedLineData;
   const elevationLineDataSmoothed = smoothGraphs ? applyRollingAverageSeries(elevationLineData, 1, smoothWindow) : elevationLineData;
@@ -123,16 +125,7 @@ export function ActivityInsights({
   const hasPowerData = records.some((r) => typeof r.power === "number" && r.power > 0);
   const hasHeartRateData = records.some((r) => typeof r.heart_rate === "number" && r.heart_rate > 0);
 
-  const lapMarkers = lapTimestampsUtc
-    .slice(1)
-    .map((ts, idx) => {
-      const parsed = Date.parse(ts);
-      if (!Number.isFinite(parsed)) return null;
-      const relMs = parsed - t0;
-      if (relMs < 0) return null;
-      return { xAxis: relMs, name: `Lap ${idx + 1}` };
-    })
-    .filter((m): m is { xAxis: number; name: string } => m !== null);
+  const lapMarkers = buildLapMarkers(records, lapTimestampsUtc, t0, xAxisMode, distanceUnit);
 
   const hrValues = records
     .map((r) => r.heart_rate)
@@ -148,14 +141,22 @@ export function ActivityInsights({
     }
   }
 
+  const sharedXAxis = {
+    type: "value",
+    axisLabel: { color: axisColor, fontSize: 11, formatter: (val: number) => formatTelemetryXAxisTick(val, xAxisMode, distanceUnit) },
+    axisLine: { lineStyle: { color: gridLine } },
+    splitLine: { show: false },
+  };
+
   const timelineOption = {
     tooltip: {
       trigger: "axis",
       ...tooltipStyle,
       formatter: (params: any[]) => {
         const p = params?.[0];
-        const rel = Number(p?.value?.[0] ?? 0);
-        let html = formatTooltipHeader(rel);
+        const rel = Number(p?.value?.[2] ?? 0);
+        const distanceMeters = (p?.value?.[4] ?? null) as number | null;
+        let html = formatTooltipHeader(rel, distanceMeters);
         for (const row of params) {
           if (row.value?.[1] !== null && row.value?.[1] !== undefined) {
             html += `<div>${row.marker} ${row.seriesName}: <strong>${Number(row.value[1]).toFixed(2)}</strong></div>`;
@@ -166,12 +167,7 @@ export function ActivityInsights({
     },
     legend: { textStyle: { color: axisColor, fontSize: 12 }, top: 0 },
     grid: { left: 50, right: 16, top: 42, bottom: 46 },
-    xAxis: {
-      type: "value",
-      axisLabel: { color: axisColor, fontSize: 11, formatter: (val: number) => formatRelTime(val) },
-      axisLine: { lineStyle: { color: gridLine } },
-      splitLine: { show: false },
-    },
+    xAxis: sharedXAxis,
     yAxis: {
       type: "value", name: speedLabel(distanceUnit),
       nameTextStyle: { color: axisColor, fontSize: 11 },
@@ -211,19 +207,15 @@ export function ActivityInsights({
       ...tooltipStyle,
       formatter: (params: any[]) => {
         const p = params?.[0];
-        const rel = Number(p?.value?.[0] ?? 0);
+        const rel = Number(p?.value?.[2] ?? 0);
+        const distanceMeters = (p?.value?.[4] ?? null) as number | null;
         const val = p?.value?.[1];
-        return `${formatTooltipHeader(rel)}<div>${p?.marker ?? ""} Elevation: <strong>${val == null ? "--" : Number(val).toFixed(2)} ${elevationLabel(distanceUnit)}</strong></div>`;
+        return `${formatTooltipHeader(rel, distanceMeters)}<div>${p?.marker ?? ""} ${tr("insights.elevation")}: <strong>${val == null ? "--" : Number(val).toFixed(2)} ${elevationLabel(distanceUnit)}</strong></div>`;
       }
     },
     legend: { textStyle: { color: axisColor, fontSize: 12 }, top: 0 },
     grid: { left: 50, right: 16, top: 42, bottom: 46 },
-    xAxis: {
-      type: "value",
-      axisLabel: { color: axisColor, fontSize: 11, formatter: (val: number) => formatRelTime(val) },
-      axisLine: { lineStyle: { color: gridLine } },
-      splitLine: { show: false },
-    },
+    xAxis: sharedXAxis,
     yAxis: {
       type: "value", name: elevationLabel(distanceUnit),
       nameTextStyle: { color: axisColor, fontSize: 11 },
@@ -289,11 +281,12 @@ export function ActivityInsights({
       ...tooltipStyle,
       formatter: (params: any[]) => {
         const p = params?.[0];
-        const rel = Number(p?.value?.[0] ?? 0);
-        let html = formatTooltipHeader(rel);
+        const rel = Number(p?.value?.[2] ?? 0);
+        const distanceMeters = (p?.value?.[4] ?? null) as number | null;
+        let html = formatTooltipHeader(rel, distanceMeters);
         for (const row of params) {
           if (row.value?.[1] !== null && row.value?.[1] !== undefined) {
-            const unit = row.seriesName === "Cadence" ? " rpm" : " W";
+            const unit = row.seriesName === tr("insights.cadence") ? " rpm" : " W";
             html += `<div>${row.marker} ${row.seriesName}: <strong>${Number(row.value[1]).toFixed(2)}${unit}</strong></div>`;
           }
         }
@@ -302,12 +295,7 @@ export function ActivityInsights({
     },
     legend: { textStyle: { color: axisColor, fontSize: 12 }, top: 0 },
     grid: { left: 44, right: hasPowerData ? 44 : 16, top: 44, bottom: 44 },
-    xAxis: {
-      type: "value",
-      axisLabel: { color: axisColor, fontSize: 11, formatter: (val: number) => formatRelTime(val) },
-      axisLine: { lineStyle: { color: gridLine } },
-      splitLine: { show: false },
-    },
+    xAxis: sharedXAxis,
     yAxis: [
       {
         type: "value", name: "rpm",
@@ -541,7 +529,7 @@ export function ActivityInsights({
         const startMs = minuteIdx * 60000;
         const endMs = (minuteIdx + 1) * 60000;
         const valueText = value === null ? "--" : `${value.toFixed(2)} ${unit}`;
-        return `<div><strong>${label}</strong></div>${formatTooltipHeader(startMs)}<div>${formatRelTime(startMs)} - ${formatRelTime(endMs)}: <strong>${valueText}</strong></div>`;
+        return `<div><strong>${label}</strong></div>${formatTooltipHeader(startMs, null, "time")}<div>${formatRelTime(startMs)} - ${formatRelTime(endMs)}: <strong>${valueText}</strong></div>`;
       },
     },
     grid: rowTop.map((top) => ({ left: 58, right: 14, top, height: rowHeight })),

--- a/src/components/ActivityInsights.tsx
+++ b/src/components/ActivityInsights.tsx
@@ -486,12 +486,13 @@ export function ActivityInsights({
   ] as const;
 
   const heatRowBounds = heatMetrics.map(() => ({ min: Number.POSITIVE_INFINITY, max: Number.NEGATIVE_INFINITY }));
-  const rawHeatCells: Array<Array<{ x: number; raw: number | null }>> = heatMetrics.map(() => []);
+  const rawHeatCells: Array<Array<{ x: number; raw: number | null; timestampMs?: number }>> = heatMetrics.map(() => []);
 
   for (let x = 0; x < heatBins; x += 1) {
     const startMs = x * 60000;
     const endMs = startMs + 60000;
     const slice = timeline.filter((d) => d.relMs >= startMs && d.relMs < endMs);
+    const timestampMs = slice[0]?.timestampMs;
     for (let row = 0; row < heatMetrics.length; row += 1) {
       const metricValue = safeAvg(slice.map((r) => heatMetrics[row].getter(r)));
       const raw = typeof metricValue === "number" && Number.isFinite(metricValue) ? Number(metricValue.toFixed(2)) : null;
@@ -499,7 +500,7 @@ export function ActivityInsights({
         heatRowBounds[row].min = Math.min(heatRowBounds[row].min, raw);
         heatRowBounds[row].max = Math.max(heatRowBounds[row].max, raw);
       }
-      rawHeatCells[row].push({ x, raw });
+      rawHeatCells[row].push({ x, raw, timestampMs });
     }
   }
 
@@ -515,6 +516,7 @@ export function ActivityInsights({
         return {
           value: [x, 0, Number(normalized.toFixed(4))],
           raw,
+          timestampMs: rowCells[x]?.timestampMs,
           label: heatMetrics[row].label,
           unit: heatMetrics[row].unit,
         };
@@ -535,8 +537,9 @@ export function ActivityInsights({
         const unit = String(p?.data?.unit ?? "");
         const startMs = minuteIdx * 60000;
         const endMs = (minuteIdx + 1) * 60000;
+        const timestampMs = (p?.data?.timestampMs ?? undefined) as number | undefined;
         const valueText = value === null ? "--" : `${value.toFixed(2)} ${unit}`;
-        return `<div><strong>${label}</strong></div>${formatTooltipHeader(startMs, null, "time")}<div>${formatRelTime(startMs)} - ${formatRelTime(endMs)}: <strong>${valueText}</strong></div>`;
+        return `<div><strong>${label}</strong></div>${formatTooltipHeader(startMs, null, "time", timestampMs)}<div>${formatRelTime(startMs)} - ${formatRelTime(endMs)}: <strong>${valueText}</strong></div>`;
       },
     },
     grid: rowTop.map((top) => ({ left: 58, right: 14, top, height: rowHeight })),

--- a/src/components/ActivityInsights.tsx
+++ b/src/components/ActivityInsights.tsx
@@ -13,6 +13,7 @@ import {
 import {
   buildLapMarkers,
   buildTelemetryPoints,
+  buildTelemetryXAxisBounds,
   formatRelTime,
   formatTelemetryTooltipHeader,
   formatTelemetryXAxisTick,
@@ -83,6 +84,7 @@ export function ActivityInsights({
   const totalDurationMs = Math.max(0, (records[records.length - 1]?.timestamp_ms ?? t0) - t0);
   const smoothWindow = smoothGraphs ? getDynamicSmoothingWindow(records.length, totalDurationMs, zoomRange) : 1;
   const telemetryPoints = buildTelemetryPoints(records, t0, xAxisMode, distanceUnit);
+  const xAxisBounds = buildTelemetryXAxisBounds(telemetryPoints);
   const formatTooltipHeader = (relMs: number, distanceMeters: number | null, mode: TelemetryXAxisMode = xAxisMode) =>
     formatTelemetryTooltipHeader(mode, t0, relMs, distanceMeters, distanceUnit);
 
@@ -143,6 +145,7 @@ export function ActivityInsights({
 
   const sharedXAxis = {
     type: "value",
+    ...xAxisBounds,
     axisLabel: { color: axisColor, fontSize: 11, formatter: (val: number) => formatTelemetryXAxisTick(val, xAxisMode, distanceUnit) },
     axisLine: { lineStyle: { color: gridLine } },
     splitLine: { show: false },

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -30,7 +30,7 @@ import {
   speedLabel,
 } from "../lib/units";
 import { useTranslation } from "../lib/i18n";
-import { hasUsableDistanceAxis, type TelemetryXAxisMode } from "../lib/telemetryAxis";
+import { hasUsableDistanceAxis, type TelemetryTimerMetadata, type TelemetryXAxisMode } from "../lib/telemetryAxis";
 
 type Props = { onLogout: () => Promise<void> };
 
@@ -48,6 +48,7 @@ type ActivityMetadata = {
   activity_metrics?: {
     vo2_max?: number | null;
   };
+  timer?: TelemetryTimerMetadata | null;
   session?: {
     beginning_body_battery?: number | null;
     ending_body_battery?: number | null;
@@ -1031,9 +1032,6 @@ export function Dashboard({ onLogout }: Props) {
       setTelemetryXAxisMode("time");
     }
   }, [selectedActivity, records.length, hasTelemetryDistanceAxis, telemetryXAxisMode]);
-  const deviceBadgeSerial = typeof selectedMetadata?.file_id?.serial_number === "number"
-    ? String(selectedMetadata.file_id.serial_number)
-    : "";
   const detailStats = useMemo(() => {
     if (!selectedActivity) return [] as Array<{ key: string; label: string; value: string; secondary?: string; icon: Icon }>;
     const out: Array<{ key: string; label: string; value: string; secondary?: string; icon: Icon }> = [];
@@ -1572,7 +1570,6 @@ export function Dashboard({ onLogout }: Props) {
                   <div className="detail-badges">
                     <span className="badge">{formatDate(selectedActivity.start_ts_utc)}</span>
                     {selectedActivity.sport && <span className="badge sport">{selectedActivity.sport}</span>}
-                    {deviceBadgeSerial && <span className="badge device">SN {deviceBadgeSerial}</span>}
                     <div className="detail-axis-toggle" aria-label={t("detail.chartXAxis")}>
                       <button
                         type="button"
@@ -1628,10 +1625,10 @@ export function Dashboard({ onLogout }: Props) {
                 </div>
               </div>
               <div className="detail-grid">
-                <div className="panel"><h3>{t("detail.heartRateAndPace")}</h3><ActivityChart records={selectedRecords} theme={theme} distanceUnit={distanceUnit} xAxisMode={telemetryXAxisMode} heartRateZoneBoundsBpm={selectedMetadata?.heart_rate_zone_bounds_bpm} zoomRange={telemetryZoom} onZoomChange={setTelemetryZoom} lapTimestampsUtc={lapTimestampsUtc} smoothGraphs={smoothGraphs} /></div>
+                <div className="panel"><h3>{t("detail.heartRateAndPace")}</h3><ActivityChart records={selectedRecords} theme={theme} distanceUnit={distanceUnit} xAxisMode={telemetryXAxisMode} heartRateZoneBoundsBpm={selectedMetadata?.heart_rate_zone_bounds_bpm} zoomRange={telemetryZoom} onZoomChange={setTelemetryZoom} lapTimestampsUtc={lapTimestampsUtc} smoothGraphs={smoothGraphs} timerMetadata={selectedMetadata?.timer} /></div>
                 <ActivityMap records={selectedRecords} mapStyle={mapStyle} setMapStyle={setMapStyle} lapTimestampsUtc={lapTimestampsUtc} />
               </div>
-              <ActivityInsights records={selectedRecords} theme={theme} distanceUnit={distanceUnit} xAxisMode={telemetryXAxisMode} heartRateZoneBoundsBpm={selectedMetadata?.heart_rate_zone_bounds_bpm} zoomRange={telemetryZoom} onZoomChange={setTelemetryZoom} lapTimestampsUtc={lapTimestampsUtc} smoothGraphs={smoothGraphs} />
+              <ActivityInsights records={selectedRecords} theme={theme} distanceUnit={distanceUnit} xAxisMode={telemetryXAxisMode} heartRateZoneBoundsBpm={selectedMetadata?.heart_rate_zone_bounds_bpm} zoomRange={telemetryZoom} onZoomChange={setTelemetryZoom} lapTimestampsUtc={lapTimestampsUtc} smoothGraphs={smoothGraphs} timerMetadata={selectedMetadata?.timer} />
               {lapRows.length > 0 && (
                 <div className="panel laps-table-panel">
                   <h3>{t("detail.laps")}</h3>

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -59,6 +59,7 @@ type ActivityMetadata = {
     total_elapsed_time_s?: number | null;
     total_distance_m?: number | null;
     total_calories?: number | null;
+    normalized_power?: number | null;
   };
   laps?: Array<{
     start_ts_utc?: string | null;
@@ -76,6 +77,7 @@ type ActivityMetadata = {
     max_cadence?: number | null;
     total_calories?: number | null;
     best_speed_m_s?: number | null;
+    normalized_power?: number | null;
   }>;
 };
 
@@ -107,6 +109,11 @@ function formatPace(secondsPerUnit: number, unit: string): string {
 function shortenFileName(name: string, maxLength = 45): string {
   if (name.length <= maxLength) return name;
   return `${name.slice(0, maxLength)}...`;
+}
+
+function isCyclingSport(sport: string | null | undefined): boolean {
+  const normalized = String(sport ?? "").trim().toLowerCase().replace(/[ -]/g, "_");
+  return normalized.includes("cycling") || normalized.includes("biking") || normalized.includes("bike");
 }
 
 function parseActivityMetadata(raw?: string): ActivityMetadata | null {
@@ -1020,6 +1027,13 @@ export function Dashboard({ onLogout }: Props) {
     () => parseActivityMetadata(selectedActivity?.metadata_json),
     [selectedActivity?.metadata_json]
   );
+  const isSelectedCycling = isCyclingSport(selectedActivity?.sport);
+  const rawSessionNormalizedPower = selectedMetadata?.session?.normalized_power;
+  const sessionNormalizedPower = isSelectedCycling
+    && typeof rawSessionNormalizedPower === "number"
+    && rawSessionNormalizedPower > 0
+    ? rawSessionNormalizedPower
+    : null;
   const lapTimestampsUtc = useMemo(
     () => (selectedMetadata?.laps ?? [])
       .map((lap) => lap.start_ts_utc ?? lap.end_ts_utc ?? "")
@@ -1061,6 +1075,7 @@ export function Dashboard({ onLogout }: Props) {
 
     if (recordStats.maxAlt > 0) push("max_alt", t("detail.maxAltitude"), `${convertElevationMeters(recordStats.maxAlt, distanceUnit).toFixed(0)} ${elevationLabel(distanceUnit)}`, "mountain");
     if (recordStats.avgPower > 0) push("avg_power", t("detail.avgPower"), `${Math.round(recordStats.avgPower)} W`, "power");
+    if (sessionNormalizedPower !== null) push("normalized_power", t("detail.normalizedPower"), `${Math.round(sessionNormalizedPower)} W`, "power");
 
     if (typeof session.avg_cadence === "number" && session.avg_cadence > 0) push("avg_cadence", t("detail.avgCadence"), `${Math.round(session.avg_cadence)} rpm`, "cadence");
     if (typeof session.max_cadence === "number" && session.max_cadence > 0) push("max_cadence", t("detail.maxCadence"), `${Math.round(session.max_cadence)} rpm`, "cadence");
@@ -1080,7 +1095,7 @@ export function Dashboard({ onLogout }: Props) {
     if (lapTimestampsUtc.length > 0) push("laps", t("detail.laps"), String(lapTimestampsUtc.length), "avg");
 
     return out;
-  }, [selectedActivity, selectedMetadata, recordStats, distanceDivisorValue, distanceSuffix, distanceUnit, lapTimestampsUtc.length, t]);
+  }, [selectedActivity, selectedMetadata, recordStats, distanceDivisorValue, distanceSuffix, distanceUnit, sessionNormalizedPower, lapTimestampsUtc.length, t]);
 
   const lapRows = useMemo(() => {
     const laps = selectedMetadata?.laps ?? [];
@@ -1110,10 +1125,12 @@ export function Dashboard({ onLogout }: Props) {
         descentMeters: lap.total_descent_m,
         avgCadence: lap.avg_cadence,
         calories: lap.total_calories,
+        normalizedPower: lap.normalized_power,
         bestPace,
       };
     });
   }, [selectedMetadata?.laps, distanceDivisorValue, distanceSuffix]);
+  const showLapNormalizedPower = isSelectedCycling && lapRows.some((lap) => typeof lap.normalizedPower === "number" && lap.normalizedPower > 0);
 
   return (
     <div className="app-shell">
@@ -1641,6 +1658,7 @@ export function Dashboard({ onLogout }: Props) {
                           <th>{t("detail.cumulativeTime")}</th>
                           <th>{t("detail.distance")}</th>
                           <th>{t("detail.avgPace")}</th>
+                          {showLapNormalizedPower && <th title={t("detail.normalizedPower")}>NP</th>}
                           <th>{t("detail.avgHr")}</th>
                           <th>{t("detail.maxHr")}</th>
                           <th>{t("detail.totalAscent")}</th>
@@ -1657,6 +1675,7 @@ export function Dashboard({ onLogout }: Props) {
                             <td>{formatDuration(lap.cumulativeSeconds)}</td>
                             <td>{lap.distanceMeters != null ? `${(lap.distanceMeters / distanceDivisorValue).toFixed(2)} ${distanceSuffix}` : "-"}</td>
                             <td>{lap.avgPace}</td>
+                            {showLapNormalizedPower && <td>{typeof lap.normalizedPower === "number" && lap.normalizedPower > 0 ? `${Math.round(lap.normalizedPower)} W` : "-"}</td>}
                             <td>{typeof lap.avgHr === "number" ? Math.round(lap.avgHr) : "-"}</td>
                             <td>{typeof lap.maxHr === "number" ? Math.round(lap.maxHr) : "-"}</td>
                             <td>{typeof lap.ascentMeters === "number" ? `${Math.round(convertElevationMeters(lap.ascentMeters, distanceUnit))} ${elevationLabel(distanceUnit)}` : "-"}</td>
@@ -1680,6 +1699,7 @@ export function Dashboard({ onLogout }: Props) {
                             const t = lapRows.reduce((a, b) => a + (b.lapTimeSec || 0), 0);
                             return d > 0 && t > 0 ? formatPace((distanceDivisorValue / (d / t)), distanceSuffix) : "-";
                           })()}</td>
+                          {showLapNormalizedPower && <td>{sessionNormalizedPower !== null ? `${Math.round(sessionNormalizedPower)} W` : "-"}</td>}
                           <td>{(() => {
                             const hrs = lapRows.map(l => l.avgHr).filter((h): h is number => typeof h === "number");
                             return hrs.length > 0 ? Math.round(hrs.reduce((a, b) => a + b, 0) / hrs.length) : "-";

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -30,6 +30,7 @@ import {
   speedLabel,
 } from "../lib/units";
 import { useTranslation } from "../lib/i18n";
+import { hasUsableDistanceAxis, type TelemetryXAxisMode } from "../lib/telemetryAxis";
 
 type Props = { onLogout: () => Promise<void> };
 
@@ -318,6 +319,7 @@ export function Dashboard({ onLogout }: Props) {
     x: number; y: number; activityId: number; activityName: string;
   } | null>(null);
   const [telemetryZoom, setTelemetryZoom] = useState<{ start: number; end: number } | null>(null);
+  const [telemetryXAxisMode, setTelemetryXAxisMode] = useState<TelemetryXAxisMode>("time");
   const [smoothGraphs, setSmoothGraphs] = useState(true);
   const [appVersion, setAppVersion] = useState("unknown");
   const [versionBadgeStatus, setVersionBadgeStatus] = useState<VersionBadgeStatus>({ state: "hidden", latestVersion: null });
@@ -481,6 +483,7 @@ export function Dashboard({ onLogout }: Props) {
   const filteredSports = Array.from(new Set(filtered.map((a) => a.sport).filter(Boolean)));
   const filteredDevices = Array.from(new Set(filtered.map((a) => a.device).filter(Boolean)));
   const selectedRecords = tab === "overview" ? overviewRecords : records;
+  const hasTelemetryDistanceAxis = useMemo(() => hasUsableDistanceAxis(records), [records]);
   const distanceDivisorValue = distanceDivisor(distanceUnit);
   const distanceSuffix = distanceLabel(distanceUnit);
   const filteredTotalDistanceM = filtered.reduce((sum, a) => sum + a.distance_m, 0);
@@ -1022,6 +1025,12 @@ export function Dashboard({ onLogout }: Props) {
       .filter((ts) => !!ts),
     [selectedMetadata]
   );
+
+  useEffect(() => {
+    if (selectedActivity && records.length > 0 && !hasTelemetryDistanceAxis && telemetryXAxisMode === "distance") {
+      setTelemetryXAxisMode("time");
+    }
+  }, [selectedActivity, records.length, hasTelemetryDistanceAxis, telemetryXAxisMode]);
   const deviceBadgeSerial = typeof selectedMetadata?.file_id?.serial_number === "number"
     ? String(selectedMetadata.file_id.serial_number)
     : "";
@@ -1564,6 +1573,24 @@ export function Dashboard({ onLogout }: Props) {
                     <span className="badge">{formatDate(selectedActivity.start_ts_utc)}</span>
                     {selectedActivity.sport && <span className="badge sport">{selectedActivity.sport}</span>}
                     {deviceBadgeSerial && <span className="badge device">SN {deviceBadgeSerial}</span>}
+                    <div className="detail-axis-toggle" aria-label={t("detail.chartXAxis")}>
+                      <button
+                        type="button"
+                        className={telemetryXAxisMode === "time" ? "active" : ""}
+                        onClick={() => setTelemetryXAxisMode("time")}
+                      >
+                        {t("detail.time")}
+                      </button>
+                      <button
+                        type="button"
+                        className={telemetryXAxisMode === "distance" ? "active" : ""}
+                        onClick={() => hasTelemetryDistanceAxis && setTelemetryXAxisMode("distance")}
+                        disabled={!hasTelemetryDistanceAxis}
+                        title={!hasTelemetryDistanceAxis ? t("detail.distanceAxisUnavailable") : undefined}
+                      >
+                        {t("detail.distance")}
+                      </button>
+                    </div>
                     <label className="detail-toggle-badge" title={t("detail.smoothGraphsTooltip")}>
                       <input
                         type="checkbox"
@@ -1601,10 +1628,10 @@ export function Dashboard({ onLogout }: Props) {
                 </div>
               </div>
               <div className="detail-grid">
-                <div className="panel"><h3>{t("detail.heartRateAndPace")}</h3><ActivityChart records={selectedRecords} theme={theme} distanceUnit={distanceUnit} heartRateZoneBoundsBpm={selectedMetadata?.heart_rate_zone_bounds_bpm} zoomRange={telemetryZoom} onZoomChange={setTelemetryZoom} lapTimestampsUtc={lapTimestampsUtc} smoothGraphs={smoothGraphs} /></div>
+                <div className="panel"><h3>{t("detail.heartRateAndPace")}</h3><ActivityChart records={selectedRecords} theme={theme} distanceUnit={distanceUnit} xAxisMode={telemetryXAxisMode} heartRateZoneBoundsBpm={selectedMetadata?.heart_rate_zone_bounds_bpm} zoomRange={telemetryZoom} onZoomChange={setTelemetryZoom} lapTimestampsUtc={lapTimestampsUtc} smoothGraphs={smoothGraphs} /></div>
                 <ActivityMap records={selectedRecords} mapStyle={mapStyle} setMapStyle={setMapStyle} lapTimestampsUtc={lapTimestampsUtc} />
               </div>
-              <ActivityInsights records={selectedRecords} theme={theme} distanceUnit={distanceUnit} heartRateZoneBoundsBpm={selectedMetadata?.heart_rate_zone_bounds_bpm} zoomRange={telemetryZoom} onZoomChange={setTelemetryZoom} lapTimestampsUtc={lapTimestampsUtc} smoothGraphs={smoothGraphs} />
+              <ActivityInsights records={selectedRecords} theme={theme} distanceUnit={distanceUnit} xAxisMode={telemetryXAxisMode} heartRateZoneBoundsBpm={selectedMetadata?.heart_rate_zone_bounds_bpm} zoomRange={telemetryZoom} onZoomChange={setTelemetryZoom} lapTimestampsUtc={lapTimestampsUtc} smoothGraphs={smoothGraphs} />
               {lapRows.length > 0 && (
                 <div className="panel laps-table-panel">
                   <h3>{t("detail.laps")}</h3>

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -97,6 +97,7 @@
   "detail.maxHr": "Max. HF",
   "detail.maxAltitude": "Max. Höhe",
   "detail.avgPower": "Ø Leistung",
+  "detail.normalizedPower": "Normalisierte Leistung",
   "detail.avgCadence": "Ø Trittfrequenz",
   "detail.maxCadence": "Max. Trittfrequenz",
   "detail.bodyBatteryChange": "Body Battery Änderung",

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -104,6 +104,8 @@
   "detail.calories": "Kalorien",
   "detail.laps": "Runden",
   "detail.smoothGraphs": "Glatte Diagramme",
+  "detail.chartXAxis": "Diagramm-X-Achse",
+  "detail.distanceAxisUnavailable": "Distanzachse für diese Aktivität nicht verfügbar",
   "detail.resetZoom": "Zoom zurücksetzen",
   "detail.heartRateAndPace": "Herzfrequenz und Tempo",
   "detail.selectActivity": "Wählen Sie eine Aktivität aus der Seitenleiste.",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -104,6 +104,7 @@
   "detail.maxHr": "Max HR",
   "detail.maxAltitude": "Max Altitude",
   "detail.avgPower": "Avg Power",
+  "detail.normalizedPower": "Normalized Power",
   "detail.avgCadence": "Avg Cadence",
   "detail.maxCadence": "Max Cadence",
   "detail.bodyBatteryChange": "Body Battery Change",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -111,6 +111,8 @@
   "detail.calories": "Calories",
   "detail.laps": "Laps",
   "detail.smoothGraphs": "Smooth graphs",
+  "detail.chartXAxis": "Chart x-axis",
+  "detail.distanceAxisUnavailable": "Distance axis unavailable for this activity",
   "detail.resetZoom": "Reset Zoom",
   "detail.heartRateAndPace": "Heart Rate and Pace",
   "detail.selectActivity": "Select an activity from the sidebar to inspect individual telemetry.",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -104,6 +104,8 @@
   "detail.calories": "Calorías",
   "detail.laps": "Vueltas",
   "detail.smoothGraphs": "Gráficos suavizados",
+  "detail.chartXAxis": "Eje X del gráfico",
+  "detail.distanceAxisUnavailable": "Eje de distancia no disponible para esta actividad",
   "detail.resetZoom": "Restablecer zoom",
   "detail.heartRateAndPace": "Frecuencia cardíaca y ritmo",
   "detail.selectActivity": "Seleccione una actividad de la barra lateral.",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -97,6 +97,7 @@
   "detail.maxHr": "FC máx.",
   "detail.maxAltitude": "Alt. máxima",
   "detail.avgPower": "Pot. media",
+  "detail.normalizedPower": "Potencia normalizada",
   "detail.avgCadence": "Cadencia media",
   "detail.maxCadence": "Cadencia máx.",
   "detail.bodyBatteryChange": "Cambio Body Battery",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -104,6 +104,8 @@
   "detail.calories": "Calories",
   "detail.laps": "Tours",
   "detail.smoothGraphs": "Graphiques lissés",
+  "detail.chartXAxis": "Axe X du graphique",
+  "detail.distanceAxisUnavailable": "Axe de distance indisponible pour cette activité",
   "detail.resetZoom": "Réinitialiser le zoom",
   "detail.heartRateAndPace": "Fréquence cardiaque et allure",
   "detail.selectActivity": "Sélectionnez une activité dans la barre latérale.",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -97,6 +97,7 @@
   "detail.maxHr": "FC max.",
   "detail.maxAltitude": "Alt. max.",
   "detail.avgPower": "Puiss. moy.",
+  "detail.normalizedPower": "Puissance normalisée",
   "detail.avgCadence": "Cadence moy.",
   "detail.maxCadence": "Cadence max.",
   "detail.bodyBatteryChange": "Variation Body Battery",

--- a/src/i18n/hu.json
+++ b/src/i18n/hu.json
@@ -97,6 +97,7 @@
   "detail.maxHr": "Max. pulzus",
   "detail.maxAltitude": "Max. magasság",
   "detail.avgPower": "Átl. teljesítmény",
+  "detail.normalizedPower": "Normalizált teljesítmény",
   "detail.avgCadence": "Átl. lépésfreki",
   "detail.maxCadence": "Max. lépésfrekv.",
   "detail.bodyBatteryChange": "Body Battery változás",

--- a/src/i18n/hu.json
+++ b/src/i18n/hu.json
@@ -104,6 +104,8 @@
   "detail.calories": "Kalória",
   "detail.laps": "Körök",
   "detail.smoothGraphs": "Simított grafikonok",
+  "detail.chartXAxis": "Grafikon X tengelye",
+  "detail.distanceAxisUnavailable": "A távolságtengely nem érhető el ehhez a tevékenységhez",
   "detail.resetZoom": "Zoom visszaállítás",
   "detail.heartRateAndPace": "Pulzus és tempó",
   "detail.selectActivity": "Válasszon tevékenységet az oldalsávból.",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -97,6 +97,7 @@
   "detail.maxHr": "FC max",
   "detail.maxAltitude": "Alt. max",
   "detail.avgPower": "Pot. media",
+  "detail.normalizedPower": "Potenza normalizzata",
   "detail.avgCadence": "Cadenza media",
   "detail.maxCadence": "Cadenza max",
   "detail.bodyBatteryChange": "Variazione Body Battery",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -104,6 +104,8 @@
   "detail.calories": "Calorie",
   "detail.laps": "Giri",
   "detail.smoothGraphs": "Grafici smussati",
+  "detail.chartXAxis": "Asse X del grafico",
+  "detail.distanceAxisUnavailable": "Asse distanza non disponibile per questa attività",
   "detail.resetZoom": "Reimposta zoom",
   "detail.heartRateAndPace": "Frequenza cardiaca e passo",
   "detail.selectActivity": "Seleziona un'attività dalla barra laterale.",

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -104,6 +104,8 @@
   "detail.calories": "カロリー",
   "detail.laps": "ラップ",
   "detail.smoothGraphs": "スムーズグラフ",
+  "detail.chartXAxis": "グラフのX軸",
+  "detail.distanceAxisUnavailable": "このアクティビティでは距離軸を使用できません",
   "detail.resetZoom": "ズームをリセット",
   "detail.heartRateAndPace": "心拍数とペース",
   "detail.selectActivity": "サイドバーからアクティビティを選択してください。",

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -97,6 +97,7 @@
   "detail.maxHr": "最大心拍",
   "detail.maxAltitude": "最大標高",
   "detail.avgPower": "平均パワー",
+  "detail.normalizedPower": "正規化パワー",
   "detail.avgCadence": "平均ケイデンス",
   "detail.maxCadence": "最大ケイデンス",
   "detail.bodyBatteryChange": "Body Battery変化",

--- a/src/i18n/ko.json
+++ b/src/i18n/ko.json
@@ -97,6 +97,7 @@
   "detail.maxHr": "최대 심박",
   "detail.maxAltitude": "최대 고도",
   "detail.avgPower": "평균 파워",
+  "detail.normalizedPower": "정규화 파워",
   "detail.avgCadence": "평균 케이던스",
   "detail.maxCadence": "최대 케이던스",
   "detail.bodyBatteryChange": "Body Battery 변화",

--- a/src/i18n/ko.json
+++ b/src/i18n/ko.json
@@ -104,6 +104,8 @@
   "detail.calories": "칼로리",
   "detail.laps": "랩",
   "detail.smoothGraphs": "부드러운 그래프",
+  "detail.chartXAxis": "차트 X축",
+  "detail.distanceAxisUnavailable": "이 활동에는 거리 축을 사용할 수 없습니다",
   "detail.resetZoom": "줌 초기화",
   "detail.heartRateAndPace": "심박수와 페이스",
   "detail.selectActivity": "사이드바에서 활동을 선택하세요.",

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -97,6 +97,7 @@
   "detail.maxHr": "Max. HF",
   "detail.maxAltitude": "Max. hoogte",
   "detail.avgPower": "Gem. vermogen",
+  "detail.normalizedPower": "Genormaliseerd vermogen",
   "detail.avgCadence": "Gem. cadans",
   "detail.maxCadence": "Max. cadans",
   "detail.bodyBatteryChange": "Body Battery wijziging",

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -104,6 +104,8 @@
   "detail.calories": "Calorieën",
   "detail.laps": "Ronden",
   "detail.smoothGraphs": "Vloeiende grafieken",
+  "detail.chartXAxis": "X-as van grafiek",
+  "detail.distanceAxisUnavailable": "Afstandsas niet beschikbaar voor deze activiteit",
   "detail.resetZoom": "Zoom resetten",
   "detail.heartRateAndPace": "Hartslag en tempo",
   "detail.selectActivity": "Selecteer een activiteit in de zijbalk.",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -104,6 +104,8 @@
   "detail.calories": "Kalorie",
   "detail.laps": "Okrążenia",
   "detail.smoothGraphs": "Wygładzone wykresy",
+  "detail.chartXAxis": "Oś X wykresu",
+  "detail.distanceAxisUnavailable": "Oś dystansu niedostępna dla tej aktywności",
   "detail.resetZoom": "Resetuj zoom",
   "detail.heartRateAndPace": "Tętno i tempo",
   "detail.selectActivity": "Wybierz aktywność z panelu bocznego.",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -97,6 +97,7 @@
   "detail.maxHr": "Maks. tętno",
   "detail.maxAltitude": "Maks. wysokość",
   "detail.avgPower": "Śr. moc",
+  "detail.normalizedPower": "Moc znormalizowana",
   "detail.avgCadence": "Śr. kadencja",
   "detail.maxCadence": "Maks. kadencja",
   "detail.bodyBatteryChange": "Zmiana Body Battery",

--- a/src/i18n/pt.json
+++ b/src/i18n/pt.json
@@ -97,6 +97,7 @@
   "detail.maxHr": "FC máx.",
   "detail.maxAltitude": "Alt. máxima",
   "detail.avgPower": "Pot. média",
+  "detail.normalizedPower": "Potência normalizada",
   "detail.avgCadence": "Cadência média",
   "detail.maxCadence": "Cadência máx.",
   "detail.bodyBatteryChange": "Variação Body Battery",

--- a/src/i18n/pt.json
+++ b/src/i18n/pt.json
@@ -104,6 +104,8 @@
   "detail.calories": "Calorias",
   "detail.laps": "Voltas",
   "detail.smoothGraphs": "Gráficos suavizados",
+  "detail.chartXAxis": "Eixo X do gráfico",
+  "detail.distanceAxisUnavailable": "Eixo de distância indisponível para esta atividade",
   "detail.resetZoom": "Redefinir zoom",
   "detail.heartRateAndPace": "Frequência cardíaca e ritmo",
   "detail.selectActivity": "Selecione uma atividade na barra lateral.",

--- a/src/i18n/ru.json
+++ b/src/i18n/ru.json
@@ -104,6 +104,7 @@
   "detail.maxHr": "Макс. ЧСС",
   "detail.maxAltitude": "Макс. высота",
   "detail.avgPower": "Средняя мощность",
+  "detail.normalizedPower": "Нормализованная мощность",
   "detail.avgCadence": "Средний каденс",
   "detail.maxCadence": "Макс. каденс",
   "detail.bodyBatteryChange": "Изменение энергии (Body Battery)",

--- a/src/i18n/ru.json
+++ b/src/i18n/ru.json
@@ -111,6 +111,8 @@
   "detail.calories": "Калории",
   "detail.laps": "Круги",
   "detail.smoothGraphs": "Сглаживание графиков",
+  "detail.chartXAxis": "Ось X графика",
+  "detail.distanceAxisUnavailable": "Ось дистанции недоступна для этой активности",
   "detail.resetZoom": "Сбросить масштаб",
   "detail.heartRateAndPace": "Пульс и темп",
   "detail.selectActivity": "Выберите активность на боковой панели для просмотра подробной телеметрии.",

--- a/src/i18n/tr.json
+++ b/src/i18n/tr.json
@@ -97,6 +97,7 @@
   "detail.maxHr": "Maks. KAH",
   "detail.maxAltitude": "Maks. Yükseklik",
   "detail.avgPower": "Ort. Güç",
+  "detail.normalizedPower": "Normalize güç",
   "detail.avgCadence": "Ort. Kadans",
   "detail.maxCadence": "Maks. Kadans",
   "detail.bodyBatteryChange": "Body Battery Değişimi",

--- a/src/i18n/tr.json
+++ b/src/i18n/tr.json
@@ -104,6 +104,8 @@
   "detail.calories": "Kalori",
   "detail.laps": "Turlar",
   "detail.smoothGraphs": "Yumuşak grafikler",
+  "detail.chartXAxis": "Grafik X ekseni",
+  "detail.distanceAxisUnavailable": "Bu aktivite için mesafe ekseni kullanılamaz",
   "detail.resetZoom": "Yakınlaştırmayı sıfırla",
   "detail.heartRateAndPace": "Kalp Atış Hızı ve Tempo",
   "detail.selectActivity": "Kenar çubuğundan bir aktivite seçin.",

--- a/src/i18n/zh.json
+++ b/src/i18n/zh.json
@@ -97,6 +97,7 @@
   "detail.maxHr": "最大心率",
   "detail.maxAltitude": "最大海拔",
   "detail.avgPower": "平均功率",
+  "detail.normalizedPower": "标准化功率",
   "detail.avgCadence": "平均步频",
   "detail.maxCadence": "最大步频",
   "detail.bodyBatteryChange": "Body Battery 变化",

--- a/src/i18n/zh.json
+++ b/src/i18n/zh.json
@@ -104,6 +104,8 @@
   "detail.calories": "卡路里",
   "detail.laps": "圈数",
   "detail.smoothGraphs": "平滑图表",
+  "detail.chartXAxis": "图表 X 轴",
+  "detail.distanceAxisUnavailable": "此活动无法使用距离轴",
   "detail.resetZoom": "重置缩放",
   "detail.heartRateAndPace": "心率与配速",
   "detail.selectActivity": "从侧边栏选择一项活动。",

--- a/src/lib/exportUtils.ts
+++ b/src/lib/exportUtils.ts
@@ -35,6 +35,16 @@ function sanitizeFileName(name: string): string {
   return name.replace(/[^a-zA-Z0-9_\-\.]/g, "_").replace(/_{2,}/g, "_");
 }
 
+function parseActivityMetadata(raw?: string): unknown {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
 /* ── CSV ─────────────────────────────────────────────────────────── */
 
 export function buildCsv(activity: Activity, records: RecordPoint[]): string {
@@ -110,6 +120,7 @@ export function buildJson(activity: Activity, records: RecordPoint[]): string {
         durationS: activity.duration_s,
         distanceM: activity.distance_m,
       },
+      metadata: parseActivityMetadata(activity.metadata_json),
       records,
     },
     null,

--- a/src/lib/telemetryAxis.ts
+++ b/src/lib/telemetryAxis.ts
@@ -3,11 +3,25 @@ import { convertDistanceMeters, distanceLabel, type DistanceUnit } from "./units
 
 export type TelemetryXAxisMode = "time" | "distance";
 
+export type TelemetryTimerMetadata = {
+  active_time_supported?: boolean;
+  intervals_reliable?: boolean;
+  stopped_intervals?: Array<{
+    start_ts_utc?: string | null;
+    end_ts_utc?: string | null;
+    duration_s?: number | null;
+    trigger?: string | null;
+    resume_trigger?: string | null;
+  }>;
+};
+
 export type TelemetryPoint = {
   x: number | null;
   relMs: number;
+  elapsedMs: number;
   timestampMs: number;
   distanceMeters: number | null;
+  record: RecordPoint;
 };
 
 export type TelemetryXAxisBounds = {
@@ -17,10 +31,70 @@ export type TelemetryXAxisBounds = {
 
 type LapMarker = { xAxis: number; name: string };
 
+type StoppedIntervalMs = {
+  startMs: number;
+  endMs: number;
+};
+
 function finiteDistanceMeters(record: RecordPoint): number | null {
   return typeof record.distance_m === "number" && Number.isFinite(record.distance_m)
     ? Math.max(0, record.distance_m)
     : null;
+}
+
+function parseTimestampMs(raw: string | null | undefined): number | null {
+  if (!raw) return null;
+  const parsed = Date.parse(raw);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function getReliableStoppedIntervals(timerMetadata?: TelemetryTimerMetadata | null): StoppedIntervalMs[] {
+  if (!timerMetadata?.active_time_supported || !timerMetadata?.intervals_reliable) return [];
+
+  const intervals = (timerMetadata.stopped_intervals ?? [])
+    .map((interval) => {
+      const startMs = parseTimestampMs(interval.start_ts_utc);
+      const endMs = parseTimestampMs(interval.end_ts_utc);
+      if (startMs === null || endMs === null || endMs <= startMs) return null;
+      return { startMs, endMs };
+    })
+    .filter((interval): interval is StoppedIntervalMs => interval !== null)
+    .sort((a, b) => a.startMs - b.startMs || a.endMs - b.endMs);
+
+  const merged: StoppedIntervalMs[] = [];
+  for (const interval of intervals) {
+    const previous = merged[merged.length - 1];
+    if (previous && interval.startMs <= previous.endMs) {
+      previous.endMs = Math.max(previous.endMs, interval.endMs);
+    } else {
+      merged.push({ ...interval });
+    }
+  }
+  return merged;
+}
+
+function isTimestampStopped(timestampMs: number, intervals: StoppedIntervalMs[]): boolean {
+  return intervals.some((interval) => timestampMs >= interval.startMs && timestampMs < interval.endMs);
+}
+
+function stoppedDurationBeforeMs(timestampMs: number, intervals: StoppedIntervalMs[]): number {
+  let stoppedMs = 0;
+  for (const interval of intervals) {
+    if (timestampMs <= interval.startMs) break;
+    stoppedMs += Math.max(0, Math.min(timestampMs, interval.endMs) - interval.startMs);
+  }
+  return stoppedMs;
+}
+
+export function activeElapsedMsAtTimestamp(
+  timestampMs: number,
+  startTimestampMs: number,
+  timerMetadata?: TelemetryTimerMetadata | null,
+): number {
+  const intervals = getReliableStoppedIntervals(timerMetadata);
+  const elapsedMs = Math.max(0, timestampMs - startTimestampMs);
+  if (!intervals.length) return elapsedMs;
+  return Math.max(0, elapsedMs - stoppedDurationBeforeMs(timestampMs, intervals));
 }
 
 export function hasUsableDistanceAxis(records: RecordPoint[]): boolean {
@@ -35,17 +109,29 @@ export function buildTelemetryPoints(
   startTimestampMs: number,
   mode: TelemetryXAxisMode,
   distanceUnit: DistanceUnit,
+  timerMetadata?: TelemetryTimerMetadata | null,
 ): TelemetryPoint[] {
-  return records.map((record) => {
+  const intervals = getReliableStoppedIntervals(timerMetadata);
+
+  return records.flatMap((record) => {
+    if (intervals.length && isTimestampStopped(record.timestamp_ms, intervals)) return [];
+
     const distanceMeters = finiteDistanceMeters(record);
-    return {
+    const elapsedMs = Math.max(0, record.timestamp_ms - startTimestampMs);
+    const relMs = intervals.length
+      ? Math.max(0, elapsedMs - stoppedDurationBeforeMs(record.timestamp_ms, intervals))
+      : elapsedMs;
+
+    return [{
       x: mode === "distance"
         ? (distanceMeters === null ? null : convertDistanceMeters(distanceMeters, distanceUnit))
-        : record.timestamp_ms - startTimestampMs,
-      relMs: record.timestamp_ms - startTimestampMs,
+        : relMs,
+      relMs,
+      elapsedMs,
       timestampMs: record.timestamp_ms,
       distanceMeters,
-    };
+      record,
+    }];
   });
 }
 
@@ -73,7 +159,11 @@ export function formatRelTime(ms: number): string {
 }
 
 export function formatAbsTime(baseTimestampMs: number, relMs: number): string {
-  const absolute = new Date(baseTimestampMs + Math.max(0, relMs));
+  return formatAbsTimestamp(baseTimestampMs + Math.max(0, relMs));
+}
+
+function formatAbsTimestamp(timestampMs: number): string {
+  const absolute = new Date(timestampMs);
   const hh = String(absolute.getHours()).padStart(2, "0");
   const mm = String(absolute.getMinutes()).padStart(2, "0");
   const ss = String(absolute.getSeconds()).padStart(2, "0");
@@ -100,12 +190,16 @@ export function formatTelemetryTooltipHeader(
   relMs: number,
   distanceMeters: number | null,
   distanceUnit: DistanceUnit,
+  timestampMs?: number,
 ): string {
   const distanceValue = distanceMeters === null ? null : convertDistanceMeters(distanceMeters, distanceUnit);
   const primary = mode === "distance" && distanceValue !== null
     ? formatDistanceAxisTick(distanceValue, distanceUnit)
     : formatRelTime(relMs);
-  const badges = [formatAbsTime(baseTimestampMs, relMs)];
+  const absoluteMs = typeof timestampMs === "number" && Number.isFinite(timestampMs)
+    ? timestampMs
+    : baseTimestampMs + Math.max(0, relMs);
+  const badges = [formatAbsTimestamp(absoluteMs)];
 
   if (mode === "distance") {
     badges.unshift(formatRelTime(relMs));
@@ -154,7 +248,13 @@ export function buildLapMarkers(
   startTimestampMs: number,
   mode: TelemetryXAxisMode,
   distanceUnit: DistanceUnit,
+  timerMetadata?: TelemetryTimerMetadata | null,
 ): LapMarker[] {
+  const intervals = getReliableStoppedIntervals(timerMetadata);
+  const activeRecords = intervals.length
+    ? records.filter((record) => !isTimestampStopped(record.timestamp_ms, intervals))
+    : records;
+
   return lapTimestampsUtc
     .slice(1)
     .map((timestamp, idx) => {
@@ -162,12 +262,12 @@ export function buildLapMarkers(
       if (!Number.isFinite(parsed)) return null;
 
       if (mode === "distance") {
-        const distanceMeters = distanceAtTimestamp(records, parsed);
+        const distanceMeters = distanceAtTimestamp(activeRecords, parsed);
         if (distanceMeters === null) return null;
         return { xAxis: convertDistanceMeters(distanceMeters, distanceUnit), name: `Lap ${idx + 1}` };
       }
 
-      const relMs = parsed - startTimestampMs;
+      const relMs = activeElapsedMsAtTimestamp(parsed, startTimestampMs, timerMetadata);
       if (relMs < 0) return null;
       return { xAxis: relMs, name: `Lap ${idx + 1}` };
     })

--- a/src/lib/telemetryAxis.ts
+++ b/src/lib/telemetryAxis.ts
@@ -1,0 +1,158 @@
+import type { RecordPoint } from "../types";
+import { convertDistanceMeters, distanceLabel, type DistanceUnit } from "./units";
+
+export type TelemetryXAxisMode = "time" | "distance";
+
+export type TelemetryPoint = {
+  x: number | null;
+  relMs: number;
+  timestampMs: number;
+  distanceMeters: number | null;
+};
+
+type LapMarker = { xAxis: number; name: string };
+
+function finiteDistanceMeters(record: RecordPoint): number | null {
+  return typeof record.distance_m === "number" && Number.isFinite(record.distance_m)
+    ? Math.max(0, record.distance_m)
+    : null;
+}
+
+export function hasUsableDistanceAxis(records: RecordPoint[]): boolean {
+  return records.some((record) => {
+    const distanceMeters = finiteDistanceMeters(record);
+    return distanceMeters !== null && distanceMeters > 0;
+  });
+}
+
+export function buildTelemetryPoints(
+  records: RecordPoint[],
+  startTimestampMs: number,
+  mode: TelemetryXAxisMode,
+  distanceUnit: DistanceUnit,
+): TelemetryPoint[] {
+  return records.map((record) => {
+    const distanceMeters = finiteDistanceMeters(record);
+    return {
+      x: mode === "distance"
+        ? (distanceMeters === null ? null : convertDistanceMeters(distanceMeters, distanceUnit))
+        : record.timestamp_ms - startTimestampMs,
+      relMs: record.timestamp_ms - startTimestampMs,
+      timestampMs: record.timestamp_ms,
+      distanceMeters,
+    };
+  });
+}
+
+export function formatRelTime(ms: number): string {
+  const totalSec = Math.floor(Math.max(0, ms) / 1000);
+  const h = Math.floor(totalSec / 3600);
+  const m = Math.floor((totalSec % 3600) / 60);
+  const s = totalSec % 60;
+  if (h > 0) {
+    return `${h}:${m.toString().padStart(2, "0")}:${s.toString().padStart(2, "0")}`;
+  }
+  return `${m}:${s.toString().padStart(2, "0")}`;
+}
+
+export function formatAbsTime(baseTimestampMs: number, relMs: number): string {
+  const absolute = new Date(baseTimestampMs + Math.max(0, relMs));
+  const hh = String(absolute.getHours()).padStart(2, "0");
+  const mm = String(absolute.getMinutes()).padStart(2, "0");
+  const ss = String(absolute.getSeconds()).padStart(2, "0");
+  return `${hh}:${mm}:${ss}`;
+}
+
+export function formatDistanceAxisTick(value: number, unit: DistanceUnit): string {
+  const abs = Math.abs(value);
+  const digits = abs >= 100 ? 0 : abs >= 10 ? 1 : 2;
+  return `${value.toFixed(digits)} ${distanceLabel(unit)}`;
+}
+
+export function formatTelemetryXAxisTick(
+  value: number,
+  mode: TelemetryXAxisMode,
+  distanceUnit: DistanceUnit,
+): string {
+  return mode === "distance" ? formatDistanceAxisTick(value, distanceUnit) : formatRelTime(value);
+}
+
+export function formatTelemetryTooltipHeader(
+  mode: TelemetryXAxisMode,
+  baseTimestampMs: number,
+  relMs: number,
+  distanceMeters: number | null,
+  distanceUnit: DistanceUnit,
+): string {
+  const distanceValue = distanceMeters === null ? null : convertDistanceMeters(distanceMeters, distanceUnit);
+  const primary = mode === "distance" && distanceValue !== null
+    ? formatDistanceAxisTick(distanceValue, distanceUnit)
+    : formatRelTime(relMs);
+  const badges = [formatAbsTime(baseTimestampMs, relMs)];
+
+  if (mode === "distance") {
+    badges.unshift(formatRelTime(relMs));
+  } else if (distanceValue !== null) {
+    badges.push(formatDistanceAxisTick(distanceValue, distanceUnit));
+  }
+
+  return `<div style="display:flex;align-items:center;gap:6px;flex-wrap:wrap;"><strong>${primary}</strong>${badges.map((label) => `<span style="display:inline-flex;align-items:center;border-radius:999px;padding:1px 6px;font-size:11px;background:rgba(148,163,184,0.22);">${label}</span>`).join("")}</div>`;
+}
+
+function distanceAtTimestamp(records: RecordPoint[], timestampMs: number): number | null {
+  let before: RecordPoint | null = null;
+  let after: RecordPoint | null = null;
+
+  for (const record of records) {
+    if (record.timestamp_ms <= timestampMs) {
+      before = record;
+    }
+    if (record.timestamp_ms >= timestampMs) {
+      after = record;
+      break;
+    }
+  }
+
+  const beforeDistance = before ? finiteDistanceMeters(before) : null;
+  const afterDistance = after ? finiteDistanceMeters(after) : null;
+
+  if (before && after && beforeDistance !== null && afterDistance !== null) {
+    if (after.timestamp_ms === before.timestamp_ms) return beforeDistance;
+    const ratio = Math.max(0, Math.min(1, (timestampMs - before.timestamp_ms) / (after.timestamp_ms - before.timestamp_ms)));
+    return beforeDistance + (afterDistance - beforeDistance) * ratio;
+  }
+
+  if (beforeDistance !== null && afterDistance !== null) {
+    return Math.abs(timestampMs - (before?.timestamp_ms ?? timestampMs)) <= Math.abs(timestampMs - (after?.timestamp_ms ?? timestampMs))
+      ? beforeDistance
+      : afterDistance;
+  }
+
+  return beforeDistance ?? afterDistance;
+}
+
+export function buildLapMarkers(
+  records: RecordPoint[],
+  lapTimestampsUtc: string[],
+  startTimestampMs: number,
+  mode: TelemetryXAxisMode,
+  distanceUnit: DistanceUnit,
+): LapMarker[] {
+  return lapTimestampsUtc
+    .slice(1)
+    .map((timestamp, idx) => {
+      const parsed = Date.parse(timestamp);
+      if (!Number.isFinite(parsed)) return null;
+
+      if (mode === "distance") {
+        const distanceMeters = distanceAtTimestamp(records, parsed);
+        if (distanceMeters === null) return null;
+        return { xAxis: convertDistanceMeters(distanceMeters, distanceUnit), name: `Lap ${idx + 1}` };
+      }
+
+      const relMs = parsed - startTimestampMs;
+      if (relMs < 0) return null;
+      return { xAxis: relMs, name: `Lap ${idx + 1}` };
+    })
+    .filter((marker): marker is LapMarker => marker !== null);
+}

--- a/src/lib/telemetryAxis.ts
+++ b/src/lib/telemetryAxis.ts
@@ -10,6 +10,11 @@ export type TelemetryPoint = {
   distanceMeters: number | null;
 };
 
+export type TelemetryXAxisBounds = {
+  min: number;
+  max?: number;
+};
+
 type LapMarker = { xAxis: number; name: string };
 
 function finiteDistanceMeters(record: RecordPoint): number | null {
@@ -42,6 +47,18 @@ export function buildTelemetryPoints(
       distanceMeters,
     };
   });
+}
+
+export function buildTelemetryXAxisBounds(points: Array<{ x: number | null }>): TelemetryXAxisBounds {
+  let max = 0;
+
+  for (const point of points) {
+    if (typeof point.x === "number" && Number.isFinite(point.x)) {
+      max = Math.max(max, point.x);
+    }
+  }
+
+  return max > 0 ? { min: 0, max } : { min: 0 };
 }
 
 export function formatRelTime(ms: number): string {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1373,6 +1373,44 @@ button:focus-visible {
   margin: 0;
 }
 
+.detail-axis-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 2px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--input-bg);
+}
+
+.detail-axis-toggle button {
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 0.72rem;
+  font-weight: 700;
+  line-height: 1;
+  padding: 0.28rem 0.55rem;
+  transition: all 160ms ease;
+}
+
+.detail-axis-toggle button.active {
+  background: var(--accent);
+  color: white;
+  box-shadow: 0 2px 8px var(--accent-glow);
+}
+
+.detail-axis-toggle button:not(.active):not(:disabled):hover {
+  color: var(--text);
+  background: var(--accent-glow);
+}
+
+.detail-axis-toggle button:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
 .badge {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- Extract session-level and lap-level `normalized_power` from FIT metadata
- Store extracted values in existing activity metadata JSON
- Show a conditional Normalized Power summary tile for cycling activities
- Show an `NP` column in the laps table when lap-level values are available
- Add localized `detail.normalizedPower` labels

## Notes
This uses FIT-provided Normalized Power values rather than recalculating NP from the imported power time series. That keeps the display aligned with the source device summary and avoids a database schema migration.

This PR is stacked on the active-time chart axes work in #47, so its diff includes those prerequisite commits until #47 is merged.

Closes #46.

## Validation
- `./node_modules/.bin/tsc --noEmit`
- locale JSON parse
- Docker rebuild/deploy from local `main`
- local app responded on `http://localhost:8088`
- visual UI validation confirmed
